### PR TITLE
Powerline: Improve rendering at small size/hidpi

### DIFF
--- a/source/Hack-Regular.ufo/glyphs/uniE_0B_0.glif
+++ b/source/Hack-Regular.ufo/glyphs/uniE_0B_0.glif
@@ -4,9 +4,11 @@
   <unicode hex="E0B0"/>
   <outline>
     <contour>
-      <point x="-20" y="-488" type="line" name="hr00"/>
-      <point x="-20" y="2001" type="line"/>
-      <point x="1116" y="757" type="line"/>
+      <point x="80" y="1914" type="line"/>
+      <point x="1233" y="698" type="line"/>
+      <point x="80" y="-492" type="line"/>
+      <point x="-80" y="-492" type="line"/>
+      <point x="-80" y="1914" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/uniE_0B_1.glif
+++ b/source/Hack-Regular.ufo/glyphs/uniE_0B_1.glif
@@ -4,12 +4,12 @@
   <unicode hex="E0B1"/>
   <outline>
     <contour>
-      <point x="1220" y="705" type="line" name="hr00"/>
-      <point x="283" y="-322" type="line" name="ab01"/>
-      <point x="194" y="-233" type="line"/>
-      <point x="1049" y="705" type="line"/>
-      <point x="194" y="1644" type="line"/>
-      <point x="283" y="1731" type="line" name="at01"/>
+      <point x="0" y="-605" type="line"/>
+      <point x="1233" y="698" type="line"/>
+      <point x="0" y="2027" type="line"/>
+      <point x="-113" y="1914" type="line"/>
+      <point x="1010" y="698" type="line"/>
+      <point x="-113" y="-492" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/uniE_0B_2.glif
+++ b/source/Hack-Regular.ufo/glyphs/uniE_0B_2.glif
@@ -4,9 +4,11 @@
   <unicode hex="E0B2"/>
   <outline>
     <contour>
-      <point x="1253" y="2001" type="line" name="hr00"/>
-      <point x="1253" y="-488" type="line"/>
-      <point x="117" y="757" type="line"/>
+      <point x="1153" y="1914" type="line"/>
+      <point x="0" y="698" type="line"/>
+      <point x="1153" y="-492" type="line"/>
+      <point x="1313" y="-492" type="line"/>
+      <point x="1313" y="1914" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/uniE_0B_3.glif
+++ b/source/Hack-Regular.ufo/glyphs/uniE_0B_3.glif
@@ -4,12 +4,12 @@
   <unicode hex="E0B3"/>
   <outline>
     <contour>
-      <point x="937" y="-322" type="line" name="hr00"/>
-      <point x="0" y="705" type="line"/>
-      <point x="937" y="1731" type="line" name="at01"/>
-      <point x="1023" y="1644" type="line"/>
-      <point x="169" y="705" type="line"/>
-      <point x="1023" y="-233" type="line"/>
+      <point x="1233" y="-605" type="line"/>
+      <point x="0" y="698" type="line"/>
+      <point x="1233" y="2027" type="line"/>
+      <point x="1343" y="1914" type="line"/>
+      <point x="223" y="698" type="line"/>
+      <point x="1346" y="-492" type="line"/>
     </contour>
   </outline>
   <lib>


### PR DESCRIPTION
After trying what must be every monospace font in existence, I have only found three so far that work well with the Powerline separator characters: DejaVu (and Menlo), Fantasque, and Terminus.  Terminus works because it is a bitmap font--no room for renderer interpretation, but also not very helpful.  So I spent some time trying to figure out how the characters work in DejaVu and Fantasque:

In DejaVu, the separators are simply about 10% bigger than the bounding box, letting them overlap with the character before and after it:

![ff-dejavu-right-triangle](https://cloud.githubusercontent.com/assets/646230/21575924/2f145af4-ceed-11e6-8189-f78f71bc2ce1.png)

In Fantasque, the designer added a "flag" on the side of the separator triangle to force some overlap:

![ff-fantasque-right-triangle](https://cloud.githubusercontent.com/assets/646230/21575927/49326098-ceed-11e6-951e-7dd9a6b5f95c.png)

which is an interesting solution, but introduced some rendering glitches in my experience.


I think the problem with Hack has been well documented over in issue #33, but here are some additional examples using Hack 2.020 on my systems:

- Xterm
![xterm-bad](https://cloud.githubusercontent.com/assets/646230/21575908/c39f420c-ceec-11e6-86bc-bb563c507e9e.png)
- Konsole sorta-HiDPI
![konsole-hidpi-bad](https://cloud.githubusercontent.com/assets/646230/21575909/d3a68232-ceec-11e6-8e39-f8ff29200a41.png)
- MinTTY (Windows)
![windows-mintty-bad](https://cloud.githubusercontent.com/assets/646230/21575912/e6276840-ceec-11e6-9db9-b6d348795690.png)
- Vim (showing other separators, including the too-short and thin arrows)
![vim-other-separators-bad](https://cloud.githubusercontent.com/assets/646230/21575936/656937b4-ceed-11e6-93ec-b5edbac462cc.png)

Notice in all of the cases there appear to be gaps or triangles that are too short or too tall.  This is all shown at size 9, but occurs at all sizes up to about 26, when the renderer doesn't have to do as much fudging to fit the characters on the pixel grid.

To solve the gap problem, I chose to take the DejaVu approach.  I started by redrawing the triangles to perfectly fill the bounding box (and recentered the point of the triangle), then scaled it horizontally by 113%.  This lets them overlap with the surrounding characters at the cost of some sharpness on the point of the triangle.  I chose a 13% increase instead of the ~10% increase I found in DejaVu because I prefered the way it rendered on my HiDPI screen at more font sizes.

To solve the height problem, I scaled the triangles vertically by 126%.  This allows the triangle to appear to perfectly mate with the preceding/following character on a wider range of line heights at the cost of appearing more narrow (a side effect of this is that the triangle matches the Hack style better, imo).  Freetype and ClearType seem smart enough to chop off the top and bottom of the triangle to fit the displayed line height.  I do not have access to macOS to see how it renders there.

- Before
![ff-hack-right-triangle-bad](https://cloud.githubusercontent.com/assets/646230/21575983/ab58d4e0-ceee-11e6-9630-147a15edec24.png)
- After
![ff-hack-right-triangle-fixed](https://cloud.githubusercontent.com/assets/646230/21575984/b0e62e9e-ceee-11e6-8146-170a098dc789.png)

To improve the separator arrow characters, I redrew them based on the exact angle formed by the scaled triangles.  I used a stroke size of 160, matching the other line drawing characters in the font.  The result is a separator arrow that completely fills the line vertically, matches the angle formed by the separator triangles, and has a thickness more in line with the Hack style.

- Before
![ff-hack-right-arrow-bad](https://cloud.githubusercontent.com/assets/646230/21575988/e56024a4-ceee-11e6-9e6a-b66d87362dd0.png)
- After
![ff-hack-right-arrow-fixed](https://cloud.githubusercontent.com/assets/646230/21575990/e93317d0-ceee-11e6-8c41-ede48c81ee62.png)
(Naturally, I made these changes for both the right and left pointing arrows.)

The results are, I believe, as good or better than the patched DejaVu font on my Freetype and ClearType terminals, at all sizes, and on two different DPI displays that I have access to.  Again, I have not been able to test this on macOS.

- Xterm
![xterm-fixed](https://cloud.githubusercontent.com/assets/646230/21576003/63e4f03e-ceef-11e6-9b3c-2f3ecfa2a026.png)
- Konsole sorta-HiDPI
![konsole-hidpi-fixed](https://cloud.githubusercontent.com/assets/646230/21576004/6b3013c8-ceef-11e6-95bf-9d341fdb3a36.png)
- MinTTY (Windows)
![windows-mintty-fixed](https://cloud.githubusercontent.com/assets/646230/21576005/6edc14a4-ceef-11e6-8435-a18278d3c367.png)
- Vim (showing other separators, including the now-taller and thicker arrows)
![vim-other-separators-fixed](https://cloud.githubusercontent.com/assets/646230/21576006/757148d4-ceef-11e6-96f7-389d295d9cec.png)

I worked with extreme precision.  The bottom of every triangle lines up with the top of the one below it, and the point on the arrows is perfectly vertically centered:

![precision](https://cloud.githubusercontent.com/assets/646230/21576008/bacfe20a-ceef-11e6-9292-2d7b71248ce2.png)

Here is Hack 2.020 with the four changed characters patched in and with a different name so that you can give it a try:

[HackTest-powerline-fixes.zip](https://github.com/chrissimpkins/Hack/files/679482/HackTest-powerline-fixes.zip)

Thanks for your consideration.