### PR TITLE
Add Yijing mono-, di-, and trigrams (primarily for vim-airline)

### DIFF
--- a/source/Hack-Bold.ufo/glyphs/uni2630.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2630.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2630" format="1">
+  <advance width="1233"/>
+  <unicode hex="2630"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2631.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2631.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2631" format="1">
+  <advance width="1233"/>
+  <unicode hex="2631"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2632.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2632.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2632" format="1">
+  <advance width="1233"/>
+  <unicode hex="2632"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2633.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2633.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2633" format="1">
+  <advance width="1233"/>
+  <unicode hex="2633"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2634.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2634.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2634" format="1">
+  <advance width="1233"/>
+  <unicode hex="2634"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2635.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2635.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2635" format="1">
+  <advance width="1233"/>
+  <unicode hex="2635"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2636.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2636.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2636" format="1">
+  <advance width="1233"/>
+  <unicode hex="2636"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni2637.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni2637.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2637" format="1">
+  <advance width="1233"/>
+  <unicode hex="2637"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni268A_.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni268A_.glif
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268A" format="1">
+  <advance width="1233"/>
+  <unicode hex="268A"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni268B_.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni268B_.glif
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268B" format="1">
+  <advance width="1233"/>
+  <unicode hex="268B"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="517" y="200" type="line"/>
+      <point x="517" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="716" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="716" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni268C_.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni268C_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268C" format="1">
+  <advance width="1233"/>
+  <unicode hex="268C"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni268D_.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni268D_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268D" format="1">
+  <advance width="1233"/>
+  <unicode hex="268D"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni268E_.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni268E_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268E" format="1">
+  <advance width="1233"/>
+  <unicode hex="268E"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Bold.ufo/glyphs/uni268F_.glif
+++ b/source/Hack-Bold.ufo/glyphs/uni268F_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268F" format="1">
+  <advance width="1233"/>
+  <unicode hex="268F"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2630.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2630.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2630" format="1">
+  <advance width="1233"/>
+  <unicode hex="2630"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2631.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2631.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2631" format="1">
+  <advance width="1233"/>
+  <unicode hex="2631"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2632.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2632.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2632" format="1">
+  <advance width="1233"/>
+  <unicode hex="2632"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2633.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2633.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2633" format="1">
+  <advance width="1233"/>
+  <unicode hex="2633"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2634.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2634.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2634" format="1">
+  <advance width="1233"/>
+  <unicode hex="2634"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2635.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2635.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2635" format="1">
+  <advance width="1233"/>
+  <unicode hex="2635"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2636.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2636.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2636" format="1">
+  <advance width="1233"/>
+  <unicode hex="2636"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni2637.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni2637.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2637" format="1">
+  <advance width="1233"/>
+  <unicode hex="2637"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni268A_.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni268A_.glif
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268A" format="1">
+  <advance width="1233"/>
+  <unicode hex="268A"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni268B_.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni268B_.glif
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268B" format="1">
+  <advance width="1233"/>
+  <unicode hex="268B"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="517" y="200" type="line"/>
+      <point x="517" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="716" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="716" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni268C_.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni268C_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268C" format="1">
+  <advance width="1233"/>
+  <unicode hex="268C"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni268D_.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni268D_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268D" format="1">
+  <advance width="1233"/>
+  <unicode hex="268D"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni268E_.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni268E_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268E" format="1">
+  <advance width="1233"/>
+  <unicode hex="268E"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-BoldItalic.ufo/glyphs/uni268F_.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/uni268F_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268F" format="1">
+  <advance width="1233"/>
+  <unicode hex="268F"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2630.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2630.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2630" format="1">
+  <advance width="1233"/>
+  <unicode hex="2630"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2631.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2631.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2631" format="1">
+  <advance width="1233"/>
+  <unicode hex="2631"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2632.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2632.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2632" format="1">
+  <advance width="1233"/>
+  <unicode hex="2632"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2633.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2633.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2633" format="1">
+  <advance width="1233"/>
+  <unicode hex="2633"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2634.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2634.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2634" format="1">
+  <advance width="1233"/>
+  <unicode hex="2634"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2635.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2635.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2635" format="1">
+  <advance width="1233"/>
+  <unicode hex="2635"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2636.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2636.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2636" format="1">
+  <advance width="1233"/>
+  <unicode hex="2636"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni2637.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni2637.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2637" format="1">
+  <advance width="1233"/>
+  <unicode hex="2637"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni268A_.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni268A_.glif
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268A" format="1">
+  <advance width="1233"/>
+  <unicode hex="268A"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni268B_.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni268B_.glif
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268B" format="1">
+  <advance width="1233"/>
+  <unicode hex="268B"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="517" y="200" type="line"/>
+      <point x="517" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="716" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="716" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni268C_.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni268C_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268C" format="1">
+  <advance width="1233"/>
+  <unicode hex="268C"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni268D_.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni268D_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268D" format="1">
+  <advance width="1233"/>
+  <unicode hex="268D"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni268E_.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni268E_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268E" format="1">
+  <advance width="1233"/>
+  <unicode hex="268E"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Italic.ufo/glyphs/uni268F_.glif
+++ b/source/Hack-Italic.ufo/glyphs/uni268F_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268F" format="1">
+  <advance width="1233"/>
+  <unicode hex="268F"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2630.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2630.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2630" format="1">
+  <advance width="1233"/>
+  <unicode hex="2630"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2631.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2631.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2631" format="1">
+  <advance width="1233"/>
+  <unicode hex="2631"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2632.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2632.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2632" format="1">
+  <advance width="1233"/>
+  <unicode hex="2632"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2633.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2633.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2633" format="1">
+  <advance width="1233"/>
+  <unicode hex="2633"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2634.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2634.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2634" format="1">
+  <advance width="1233"/>
+  <unicode hex="2634"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2635.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2635.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2635" format="1">
+  <advance width="1233"/>
+  <unicode hex="2635"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2636.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2636.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2636" format="1">
+  <advance width="1233"/>
+  <unicode hex="2636"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268A" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni2637.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni2637.glif
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni2637" format="1">
+  <advance width="1233"/>
+  <unicode hex="2637"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+    <component base="uni268B" yOffset="1293"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni268A_.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni268A_.glif
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268A" format="1">
+  <advance width="1233"/>
+  <unicode hex="268A"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni268B_.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni268B_.glif
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268B" format="1">
+  <advance width="1233"/>
+  <unicode hex="268B"/>
+  <outline>
+    <contour>
+      <point x="82" y="200" type="line"/>
+      <point x="517" y="200" type="line"/>
+      <point x="517" y="0" type="line"/>
+      <point x="82" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="716" y="200" type="line"/>
+      <point x="1151" y="200" type="line"/>
+      <point x="1151" y="0" type="line"/>
+      <point x="716" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni268C_.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni268C_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268C" format="1">
+  <advance width="1233"/>
+  <unicode hex="268C"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni268D_.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni268D_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268D" format="1">
+  <advance width="1233"/>
+  <unicode hex="268D"/>
+  <outline>
+    <component base="uni268A"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni268E_.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni268E_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268E" format="1">
+  <advance width="1233"/>
+  <unicode hex="268E"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268A" yOffset="646"/>
+  </outline>
+</glyph>

--- a/source/Hack-Regular.ufo/glyphs/uni268F_.glif
+++ b/source/Hack-Regular.ufo/glyphs/uni268F_.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni268F" format="1">
+  <advance width="1233"/>
+  <unicode hex="268F"/>
+  <outline>
+    <component base="uni268B"/>
+    <component base="uni268B" yOffset="646"/>
+  </outline>
+</glyph>


### PR DESCRIPTION
14 glyphs from 2630-2637 and 268A-268F.  These are based on the glyphs from DejaVu Sans (not mono).  The widths were copied from 268A and 268B in DejaVu Sans Mono Regular, which are the only two of the 14 to exist.

2630, trigram for heaven, consisting of three horizontal lines is used to indicate the line count in vim-airline.  Other symbols my be used to indicate a column layout.

- URxvt
![trigram-urxvt](https://cloud.githubusercontent.com/assets/646230/21709181/fd7d2ccc-d3ac-11e6-82f1-d7afa982ff44.png)
- Details
![trigram-heaven](https://cloud.githubusercontent.com/assets/646230/21709225/6bfbcdf2-d3ad-11e6-95d9-cbbcb5b15862.png)

Here is Hack v2.020 with these new glyphs patched in (along with my changes from #234).
[Hack-v2.020-with-ngrams.zip](https://github.com/chrissimpkins/Hack/files/689089/Hack-v2.020-with-ngrams.zip)

Re: issue #201