### PR TITLE
adds issue reporting and pull request documentation to contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,21 @@ Hack is a general purpose typeface for source code. The _needs of the many_ desc
 - **Visual semantics** - establish semantic commonalities for glyphs used in source code text and create common visual designs within these semantic groups
 
 
+# Issue Reporting
+
+Issue reports from users are extremely important to foster the ongoing development of the typeface.  If you identify a problem, we request that you report it through a new issue report on the Github repository.  Please include the following information in your (bug) issue report:
+
+- Hack font version
+- variant(s) of the Hack fonts that are affected (Regular, Bold, Italic, BoldItalic)
+- font size at which the problem was observed and whether it occurs at other sizes within the Core design target range (see above)
+- operating system and version
+- application where the issue was observed and version (important for us to understand the renderer involved)
+- screenshot images that visually demonstrate the problem
+
+Please describe what led to the problem in detail.
+
+
+# Pull Requests
+
+We highly encourage contributions to the Hack typeface source code, repository scripts, and documentation.  Please read and understand our design philosophy statement above in order to avoid frustration with work that we cannot merge upstream.  We are willing to consider pull requests that follow these design guidelines.  If you intend to submit changes that fall outside of the design guidelines, we highly suggest that you post an issue report with the proposed changes for discussion *before you do the work*.  There is never wasted work.  If a change is of value to you, it is likely to be of value to others and this is the perfect situation for a downstream fork of Hack that you can maintain and share with other users.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ Before you report an issue, please confirm that you have installed the current v
 
 If you identify a problem, we request that you report it through a new issue report on the Github repository.  Please include the following information in your (bug) issue report:
 
-- Hack font version (or timeframe when you installed it and where you obtained the fonts for install)
+- Font version (or timeframe when you downloaded the fonts if you do not know)
+- Where you obtained the fonts (e.g. repository download, package manager, another source)
 - variant(s) of the Hack fonts that are affected (Regular, Bold, Italic, BoldItalic)
 - font size at which the problem was observed and whether it occurs at other sizes within the Core design target range (see above)
 - operating system and version
@@ -58,27 +59,18 @@ Contributors who modify the UFO source code should familiarize themselves with t
 
 For pull requests that modify the design of the typeface, we request that you limit your source commits to the following changes unless we have discussed and explicitly requested additional file changes as part of the contribution.
 
-### Single glyph modifications
 
-- Only include the modified `glyphs/*.glif` source file in commits
-- Modification of other source files is not acceptable
-
-### Multiple glyph modifications
+### Glyph modifications
 
 - Only include the modified `glyphs/*.glif` source files for the modified glyphs in commits
 - Modification of other source files is not acceptable
 
-### Glyph additions
+### Glyph additions and deletions
 
-- Include the added `glyphs/*.glif` source file(s) in commits
+- Include the added and/or deleted `glyphs/*.glif` source file(s) in commits
 - Include the `glyphs/contents.plist` source file in commits
 - Modification of other source files is not acceptable
 
-### Glyph deletions
-
-- Include the deleted `glyphs/*.glif` source file(s) in commits
-- Include the `glyphs/contents.plist` source file in commits
-- Modification of other source files is not acceptable
 
 ### Other Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,19 @@ Hack is a monospaced typeface that is designed to optimize the display of source
 
 This document outlines the core ideas on which we build to continually improve Hack. Ideally, they serve as a final rationale to decide disputes of whatever nature.
 
-Design is a highly opinionated topic. Being a collaborative effort, we prefer to focus on the discussion about a change, rather than the final product of a change. In practical terms this means that for any substantial amount of work, we'd like to see an Issue Report or Pull Request which presents an idea or the approach for a change. By keeping the discussion open, not only will you get community feedback, it also allows us to judge your contribution on more than the final product.
+Design is a highly subjective and opinionated topic. Being a collaborative effort, we prefer to focus on the discussion about a change, rather than the final product of a change. In practical terms this means that for any substantial amount of work, we'd like to see an Issue Report or Pull Request which presents an idea or the approach for a change. By keeping the discussion open, not only will you get community feedback, it also allows us to judge your contribution on more than the final product.
 
 ## Design Targets
 
-Hack is a general purpose typeface for source code. The _needs of the many_ describe our core design targets. Generally, an issue that affects 90% of users, gets a higher priority than one that 'only' affects 10%.
+Hack is a general purpose typeface for source code. The _needs of the many_ describe our core design targets. Generally, an issue that affects a majority of users receives higher priority than an issue that affects a minority of users.
 
 ### Core
 
-- **ASCII glyph set**; generally speaking, all source code is limited to ASCII. Content/comments/documentation, on the other hand, often includes non-ASCII characters. The former gets precendence over the latter.
+- **ASCII glyph set**; generally speaking, all source code is limited to the ASCII set. Content/comments/documentation, on the other hand, often includes non-ASCII characters. The former gets precedence over the latter.
 - We focus on an accepted **single glyph style** for each glyph in the typeface sets.  Glyph shape changes that are intended to address our design goals take precedence over changes that are purely subjective in nature.
 - Font-sizes between **8-14 px**, line-height >= 1
-- **Cross-platform**, cross font renderer support on Linux, OS X, and Windows operating systems
-- Usage in **common developer scenarios** (on digital displays): text editors, terminals, embedded as webfont, etc.
+- **Cross-platform**, cross font renderer support on Linux, OS X, and Windows operating systems.  Changes that address cross platform issues take precedence over issues that address platform specific issues.  Changes that improve the typeface on some platforms but decrease its usability on others are generally not acceptable and belong in a fork that is intended for the platforms targeted for these changes.
+- Usage in **common source code display scenarios** (on digital displays): text editors, terminals, embedded as web fonts, etc.
 
 ## Goals, areas of improvement
 
@@ -27,9 +27,13 @@ Hack is a general purpose typeface for source code. The _needs of the many_ desc
 
 # Issue Reporting
 
-Issue reports from users are extremely important to foster the ongoing development of the typeface.  If you identify a problem, we request that you report it through a new issue report on the Github repository.  Please include the following information in your (bug) issue report:
+Issue reports from users are extremely important to foster the ongoing development of the typeface.
 
-- Hack font version
+Before you report an issue, please confirm that you have installed the current version of the Hack typeface on your system. See the [README.md page](README.md) for details.
+
+If you identify a problem, we request that you report it through a new issue report on the Github repository.  Please include the following information in your (bug) issue report:
+
+- Hack font version (or timeframe when you installed it and where you obtained the fonts for install)
 - variant(s) of the Hack fonts that are affected (Regular, Bold, Italic, BoldItalic)
 - font size at which the problem was observed and whether it occurs at other sizes within the Core design target range (see above)
 - operating system and version
@@ -41,5 +45,58 @@ Please describe what led to the problem in detail.
 
 # Pull Requests
 
-We highly encourage contributions to the Hack typeface source code, repository scripts, and documentation.  Please read and understand our design philosophy statement above in order to avoid frustration with work that we cannot merge upstream.  We are willing to consider pull requests that follow these design guidelines.  If you intend to submit changes that fall outside of the design guidelines, we highly suggest that you post an issue report with the proposed changes for discussion *before you do the work*.  There is never wasted work.  If a change is of value to you, it is likely to be of value to others and this is the perfect situation for a downstream fork of Hack that you can maintain and share with other users.
+We highly encourage contributions to the Hack typeface source code, repository scripts, and documentation.  To view areas where we currently need your help, check out the active issues [Contribute! label](https://github.com/source-foundry/Hack/labels/Contribute%21).
 
+
+Please read and understand our design philosophy statement above in order to avoid frustration with work that we cannot merge upstream.  We are willing to consider pull requests that follow these design guidelines. Having said that, there is never wasted work.  If a change is of value to you, it is likely to be of value to others and this is the perfect situation for a downstream fork of Hack that you can maintain and share with other users.
+
+## Pull requests for design changes
+
+Contributors who submit source modifications intended for merge into the Hack repository must license these changes according to [LICENSE.md](LICENSE.md).  If this is not acceptable, please do not submit your work for consideration.
+
+Contributors who modify the UFO source code should familiarize themselves with the UFO source specification.  The Hack typeface currently uses version 2 of the UFO specification and documentation is available [here](http://unifiedfontobject.org/versions/ufo2/index.html).
+
+For pull requests that modify the design of the typeface, we request that you limit your source commits to the following changes unless we have discussed and explicitly requested additional file changes as part of the contribution.
+
+### Single glyph modifications
+
+- Only include the modified `glyphs/*.glif` source file in commits
+- Modification of other source files is not acceptable
+
+### Multiple glyph modifications
+
+- Only include the modified `glyphs/*.glif` source files for the modified glyphs in commits
+- Modification of other source files is not acceptable
+
+### Glyph additions
+
+- Include the added `glyphs/*.glif` source file(s) in commits
+- Include the `glyphs/contents.plist` source file in commits
+- Modification of other source files is not acceptable
+
+### Glyph deletions
+
+- Include the deleted `glyphs/*.glif` source file(s) in commits
+- Include the `glyphs/contents.plist` source file in commits
+- Modification of other source files is not acceptable
+
+### Other Issues
+
+- commits that add or delete UFO source files outside of the above recommendations will not be accepted
+
+
+## Pull requests for script changes
+
+Contributors who submit script source modifications intended for merge into the Hack repository must license these changes according to the license specified in the script header for existing files.  For new files, please discuss your license with us in an issue report before you submit your work for consideration.
+
+Please add an issue report that describes the issue that your pull request is intended to address (and that the pull request will close when merged).
+
+We request that you try not to add additional external dependencies to the project with your commits.  This has the potential to prevent releases of Hack packages on some platforms.  If you need to add a new dependency to the project, we suggest that you discuss this with us in advance through an issue report so that we can confirm that this is acceptable.
+
+## Pull requests for documentation changes
+
+We love help with our docs!  This includes anything from simple misspelling or grammar changes to major revisions of poorly written sections.  For minor changes, a simple pull request suffices.  For major edits, we recommend that you discuss the changes with us in an issue report before you go to the effort.
+
+# Contributors
+
+Contributions to the project come in many forms and we **want** to broadly acknowledge those who spend time and effort to improve the project.  We understand that many contributions to open source projects are not in the form of changes to the code base and therefore not automatically recognized in the Github repository UI.  We maintain a [CONTRIBUTORS.md](docs/CONTRIBUTORS.md) list to acknowledge project contributors for this reason.  If you feel that you have helped to improve Hack and your contributions have been overlooked (i.e. you are not included on the contributors list), please let us know so that we can rectify this issue!  In all likelihood this is an oversight and not intended to be a slight.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Hack is a monospaced typeface that is designed to optimize the display of source
 
 This document outlines the core ideas on which we build to continually improve Hack. Ideally, they serve as a final rationale to decide disputes of whatever nature.
 
+Design is a highly opinionated topic. Being a collaborative effort, we prefer to focus on the discussion about a change, rather than the final product of a change. In practical terms this means that for any substantial amount of work, we'd like to see an Issue Report or Pull Request which presents an idea or the approach for a change. By keeping the discussion open, not only will you get community feedback, it also allows us to judge your contribution on more than the final product.
+
 ## Design Targets
 
 Hack is a general purpose typeface for source code. The _needs of the many_ describe our core design targets. Generally, an issue that affects 90% of users, gets a higher priority than one that 'only' affects 10%.


### PR DESCRIPTION
@burodepeper 

This commit is based on `contributing-docs` and adds a draft of issue reporting and pull request documentation to the CONTRIBUTING.md file.

Let me know what you think.

TODO: 

- [x] add install current version of Hack recommendations (https://github.com/source-foundry/Hack/pull/275#discussion_r134414873)
- [x] modify to "Your version of Hack, or a rough estimate of when you've installed the Hack fonts" (https://github.com/source-foundry/Hack/pull/275#discussion_r134414259)
- [x]  add acceptable file modifications for single glyph changes documentation
- [x] add acceptable file modifications for multiple glyph changes documentation
- [x] add acceptable glyph deletions and additions documentation with acceptable file changes
- [x] add acceptable file deletions documentation
- [x] add URL for issue reports filtered by a label that indicates user contributions requested (under discussion)
- [ ] merge to master branch