### PR TITLE
Declare success_indicator as a local variable, not a GLOBAL CONSTANT

### DIFF
--- a/postbuild_processing/posthinted_builds/dev-versioner.py
+++ b/postbuild_processing/posthinted_builds/dev-versioner.py
@@ -11,9 +11,9 @@ import sys
 from fontTools import ttLib
 
 VERSION_STRING="Version 2.020;DEV-03192016;"
-SUCCESS_INDICATOR = 0
 
 def main(argv):
+    success_indicator = 0
     for font_variant_path in argv:
         tt = ttLib.TTFont(font_variant_path)
         namerecord_list = tt['name'].__dict__['names']
@@ -26,22 +26,21 @@ def main(argv):
                 record.__dict__['string'] = VERSION_STRING
 
                 tt.save(outfile_path)
-                SUCCESS_INDICATOR += 1
+                success_indicator += 1
 
             elif record.__dict__['langID'] == 1033 and record.__dict__['nameID'] == 5:
                 record.__dict__['string'] = VERSION_STRING.encode('utf_16_be')  # UTF-16 big endian encoding for the Microsoft tables
 
                 tt.save(outfile_path)
-                SUCCESS_INDICATOR += 1
+                success_indicator += 1
 
-        if SUCCESS_INDICATOR == 0:
+        if success_indicator == 0:
             print("[ERROR] Unable to complete the name table update for " + font_variant_path)
-        elif SUCCESS_INDICATOR == 1:  # should equal 2 if both name tables were successfully updated
+        elif success_indicator == 1:  # should equal 2 if both name tables were successfully updated
             print("[ERROR] Incomplete name table update for " + font_variant_path)
 
-        SUCCESS_INDICATOR = 0   # reset success indicator
+        success_indicator = 0   # reset success indicator
 
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-


### PR DESCRIPTION
Redo #312 on the correct branch.
Declare success_indicator as a local variable, not a GLOBAL CONSTANT.

* By convention, values that may change at runtime should not be in UPPERCASE.
* A global variable can be read from either with or without a global statement
* A global variable can be written to only when preceded by a global statement
```python 
>>> SUCCESS_INDICATOR = 0
>>> def read_from_global():
...     print(SUCCESS_INDICATOR)
...
>>> def write_to_declared__global():
...     global SUCCESS_INDICATOR
...     SUCCESS_INDICATOR += 1
...
>>> def write_to_undeclared__global():
...     SUCCESS_INDICATOR += 1
...
>>> read_from_global()
0
>>> write_to_declared__global()
>>> read_from_global()
1
>>> write_to_undeclared__global()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 2, in write_to_undeclared__global
UnboundLocalError: local variable 'SUCCESS_INDICATOR' referenced before assignment
```