### PR TITLE
Hack-Regular hint updates U+0030 (zero, glyph ID 548)

### DIFF
--- a/postbuild_processing/tt-hinting/Hack-Regular-TA.txt
+++ b/postbuild_processing/tt-hinting/Hack-Regular-TA.txt
@@ -1,8 +1,3 @@
-# [ U+0030 ] Adjust fill in the zero glyph
-# uni0030  left  40
-# uni0030  touch 39,40,71  y -0.5 @ 7
-# uni0030  touch 39,40,71  y -1   @ 8,12-18
-# uni0030  touch 55,56,57  y -1   @ 19-25
 
 # U+0023 numbersign glyph ID 582
 uni0023 touch 0,1,2,3,18,19,20,21,22,23,24,25,26,27,28,31 x 0.25  @ 13

--- a/postbuild_processing/tt-hinting/Hack-Regular-TA.txt
+++ b/postbuild_processing/tt-hinting/Hack-Regular-TA.txt
@@ -25,4 +25,6 @@ uni0025 touch 40,41,42,43        y -0.25  @14
 uni002B touch 4,5,10,11          y 0.5    @12
 uni002B touch 4,5                y 1.0    @13
 
-
+# U+0030 zero glyph ID 548
+uni0030 touch 35,36,45,46,47,56  y -0.5   @8
+uni0030 touch 35,36,56           y -1.0   @12,13,14


### PR DESCRIPTION
Based on `dev-build-scripts`

- adds manual hint updates for the U+0030 (zero) glyph in the regular set

Propose merge to `dev-build-scripts` where previous hinting work currently resides in preparation for merge to `dev` after review of #309 is complete.

Pre/post images for all changes are available in #315 