### PR TITLE
modified Hack license to MIT license (#271)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,49 +1,30 @@
-## License
+The work in the Hack project is Copyright 2017 Source Foundry Authors and licensed under the MIT License
 
-Hack Copyright 2015, Christopher Simpkins with Reserved Font Name "Hack".
+The work in the DejaVu project was committed to the public domain.
 
 Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
 
-DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+### MIT License
 
+Copyright (c) 2017 Source Foundry Authors
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-These licenses are copied below.
-
-
-### Hack Open Font License v2.0
-
-(Version 1.0 - 06 September 2015)
-
-(Version 2.0 - 27 September 2015)
-
-Copyright 2015 by Christopher Simpkins. All Rights Reserved.
-
-DEFINITIONS
-
-"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
-
-PERMISSION AND CONDITIONS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
-
-(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
-
-(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
-
-(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
-
-TERMINATION
-
-This license becomes null and void if any of the above conditions are not met.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-
-Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
-
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ### BITSTREAM VERA LICENSE
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pre, code { font-family: Hack, monospace; }
 
 ## Resources
 * [About Hack](docs/ABOUT.md)
-* [Full specimen](http://chrissimpkins.github.io/Hack/font-specimen.html)
+* [Full specimen](http://source-foundry.github.io/Hack/font-specimen.html)
 * [Changelog](CHANGELOG.md)
 * [Project website](http://sourcefoundry.org/hack/)
 * [Contributors](docs/CONTRIBUTORS.md)
@@ -120,11 +120,11 @@ pre, code { font-family: Hack, monospace; }
 
 ## License
 
-**Hack** &copy; 2015-2017, Christopher Simpkins (with Reserved Font Name _Hack_).
+**Hack** work is &copy; 2017 Source Foundry Authors. MIT License
 
-**Bitstream Vera Sans Mono** &copy; 2003 Bitstream, Inc. (with Reserved Font Names _Bitstream_ and _Vera_).
+**Bitstream Vera Sans Mono** &copy; 2003 Bitstream, Inc. (with Reserved Font Names _Bitstream_ and _Vera_). Bitstream Vera License.
 
-See [LICENSE.md](https://github.com/chrissimpkins/Hack/blob/master/LICENSE.md) for the full texts of the licenses.
+See [LICENSE.md](https://github.com/source-foundry/Hack/blob/master/LICENSE.md) for the full texts of the licenses.
 
 
 

--- a/source/Hack-Bold.ufo/fontinfo.plist
+++ b/source/Hack-Bold.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 	<key>capHeight</key>
 	<integer>1495</integer>
 	<key>copyright</key>
-	<string>Copyright (c) 2017 Christopher Simpkins / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
+	<string>Copyright (c) 2017 Source Foundry Authors / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
@@ -19,7 +19,7 @@
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
-	<string>2017/07/15 12:00:00</string>
+	<string>2017/09/23 12:00:00</string>
 	<key>openTypeHeadFlags</key>
 	<array>
 	</array>
@@ -34,52 +34,37 @@
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
-	<string>Christopher Simpkins</string>
+	<string>Source Foundry Authors</string>
 	<key>openTypeNameDesignerURL</key>
-	<string>https://github.com/chrissimpkins/Hack</string>
+	<string>https://github.com/source-foundry/Hack</string>
 	<key>openTypeNameLicense</key>
-	<string>Hack Copyright 2017, Christopher Simpkins with Reserved Font Name "Hack".
+	<string>The work in the Hack project is Copyright 2017 Source Foundry Authors and licensed under the MIT License
+
+The work in the DejaVu project was committed to the public domain.
 
 Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
 
-DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+MIT License
 
-This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+Copyright (c) 2017 Source Foundry Authors
 
-These licenses are copied below.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-HACK OPEN FONT LICENSE v2.0
-
-(Version 1.0 - 06 September 2015)
-
-(Version 2.0 - 27 September 2015)
-
-Copyright 2015 by Christopher Simpkins. All Rights Reserved.
-
-DEFINITIONS
-
-"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
-
-PERMISSION AND CONDITIONS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
-
-(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
-
-(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
-
-(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
-
-TERMINATION
-
-This license becomes null and void if any of the above conditions are not met.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-
-Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
-
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 BITSTREAM VERA LICENSE
 
@@ -99,7 +84,7 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
 
 Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org.</string>
 	<key>openTypeNameLicenseURL</key>
-	<string>https://github.com/chrissimpkins/Hack/blob/master/LICENSE.md</string>
+	<string>https://github.com/source-foundry/Hack/blob/master/LICENSE.md</string>
 	<key>openTypeNameManufacturer</key>
 	<string>Source Foundry</string>
 	<key>openTypeNameManufacturerURL</key>
@@ -111,7 +96,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameSampleText</key>
 	<string></string>
 	<key>openTypeNameUniqueID</key>
-	<string>ChristopherSimpkins: Hack Bold: 2015</string>
+	<string>SourceFoundry: Hack Bold: 2017</string>
 	<key>openTypeNameVersion</key>
 	<string>Version 3.000</string>
 	<key>openTypeOS2CodePageRanges</key>

--- a/source/Hack-BoldItalic.ufo/fontinfo.plist
+++ b/source/Hack-BoldItalic.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 	<key>capHeight</key>
 	<integer>1495</integer>
 	<key>copyright</key>
-	<string>Copyright (c) 2017 Christopher Simpkins / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
+	<string>Copyright (c) 2017 Source Foundry Authors / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
@@ -21,7 +21,7 @@
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
-	<string>2017/07/15 12:00:00</string>
+	<string>2017/09/23 12:00:00</string>
 	<key>openTypeHeadFlags</key>
 	<array>
 	</array>
@@ -36,53 +36,37 @@
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
-	<string>Christopher Simpkins</string>
+	<string>Source Foundry Authors</string>
 	<key>openTypeNameDesignerURL</key>
-	<string>https://github.com/chrissimpkins/Hack</string>
+	<string>https://github.com/source-foundry/Hack</string>
 	<key>openTypeNameLicense</key>
-	<string>Hack Copyright 2017, Christopher Simpkins with Reserved Font Name "Hack".
+	<string>The work in the Hack project is Copyright 2017 Source Foundry Authors and licensed under the MIT License
+
+The work in the DejaVu project was committed to the public domain.
 
 Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
 
-DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+MIT License
 
+Copyright (c) 2017 Source Foundry Authors
 
-This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-These licenses are copied below.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-
-HACK OPEN FONT LICENSE v2.0
-
-(Version 1.0 - 06 September 2015)
-
-(Version 2.0 - 27 September 2015)
-
-Copyright 2015 by Christopher Simpkins. All Rights Reserved.
-
-DEFINITIONS
-
-"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
-
-PERMISSION AND CONDITIONS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
-
-(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
-
-(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
-
-(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
-
-TERMINATION
-
-This license becomes null and void if any of the above conditions are not met.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-
-Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
-
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 BITSTREAM VERA LICENSE
 
@@ -102,7 +86,7 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
 
 Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org.</string>
 	<key>openTypeNameLicenseURL</key>
-	<string>https://github.com/chrissimpkins/Hack/blob/master/LICENSE.md</string>
+	<string>https://github.com/source-foundry/Hack/blob/master/LICENSE.md</string>
 	<key>openTypeNameManufacturer</key>
 	<string>Source Foundry</string>
 	<key>openTypeNameManufacturerURL</key>
@@ -114,7 +98,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameSampleText</key>
 	<string></string>
 	<key>openTypeNameUniqueID</key>
-	<string>ChristopherSimpkins: Hack Bold Italic: 2015</string>
+	<string>SourceFoundry: Hack Bold Italic: 2017</string>
 	<key>openTypeNameVersion</key>
 	<string>Version 3.000</string>
 	<key>openTypeOS2CodePageRanges</key>

--- a/source/Hack-Italic.ufo/fontinfo.plist
+++ b/source/Hack-Italic.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 	<key>capHeight</key>
 	<integer>1493</integer>
 	<key>copyright</key>
-	<string>Copyright (c) 2017 Christopher Simpkins / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
+	<string>Copyright (c) 2017 Source Foundry Authors / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
@@ -21,7 +21,7 @@
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
-	<string>2017/07/15 12:00:00</string>
+	<string>2017/09/23 12:00:00</string>
 	<key>openTypeHeadFlags</key>
 	<array>
 	</array>
@@ -36,54 +36,37 @@
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
-	<string>Christopher Simpkins</string>
+	<string>Source Foundry Authors</string>
 	<key>openTypeNameDesignerURL</key>
-	<string>https://github.com/chrissimpkins/Hack</string>
+	<string>https://github.com/source-foundry/Hack</string>
 	<key>openTypeNameLicense</key>
-	<string>Hack Copyright 2017, Christopher Simpkins with Reserved Font Name "Hack".
+	<string>The work in the Hack project is Copyright 2017 Source Foundry Authors and licensed under the MIT License
+
+The work in the DejaVu project was committed to the public domain.
 
 Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
 
-DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+MIT License
 
+Copyright (c) 2017 Source Foundry Authors
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-These licenses are copied below.
-
-
-HACK OPEN FONT LICENSE v2.0
-
-(Version 1.0 - 06 September 2015)
-
-(Version 2.0 - 27 September 2015)
-
-Copyright 2015 by Christopher Simpkins. All Rights Reserved.
-
-DEFINITIONS
-
-"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
-
-PERMISSION AND CONDITIONS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
-
-(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
-
-(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
-
-(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
-
-TERMINATION
-
-This license becomes null and void if any of the above conditions are not met.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-
-Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
-
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 BITSTREAM VERA LICENSE
 
@@ -103,7 +86,7 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
 
 Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org.</string>
 	<key>openTypeNameLicenseURL</key>
-	<string>https://github.com/chrissimpkins/Hack/blob/master/LICENSE.md</string>
+	<string>https://github.com/source-foundry/Hack/blob/master/LICENSE.md</string>
 	<key>openTypeNameManufacturer</key>
 	<string>Source Foundry</string>
 	<key>openTypeNameManufacturerURL</key>
@@ -115,7 +98,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameSampleText</key>
 	<string></string>
 	<key>openTypeNameUniqueID</key>
-	<string>ChristopherSimpkins: Hack Italic: 2015</string>
+	<string>SourceFoundry: Hack Italic: 2017</string>
 	<key>openTypeNameVersion</key>
 	<string>Version 3.000</string>
 	<key>openTypeOS2CodePageRanges</key>

--- a/source/Hack-Regular.ufo/fontinfo.plist
+++ b/source/Hack-Regular.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 	<key>capHeight</key>
 	<integer>1493</integer>
 	<key>copyright</key>
-	<string>Copyright (c) 2017 Christopher Simpkins / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
+	<string>Copyright (c) 2017 Source Foundry Authors / Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.</string>
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
@@ -19,7 +19,7 @@
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
-	<string>2017/07/15 12:00:00</string>
+	<string>2017/09/23 12:00:00</string>
 	<key>openTypeHeadFlags</key>
 	<array>
 	</array>
@@ -34,53 +34,37 @@
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
-	<string>Christopher Simpkins</string>
+	<string>Source Foundry Authors</string>
 	<key>openTypeNameDesignerURL</key>
-	<string>https://github.com/chrissimpkins/Hack</string>
+	<string>https://github.com/source-foundry/Hack</string>
 	<key>openTypeNameLicense</key>
-	<string>Hack Copyright 2017, Christopher Simpkins with Reserved Font Name "Hack".
+	<string>The work in the Hack project is Copyright 2017 Source Foundry Authors and licensed under the MIT License
+
+The work in the DejaVu project was committed to the public domain.
 
 Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
 
-DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+MIT License
 
+Copyright (c) 2017 Source Foundry Authors
 
-This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-These licenses are copied below.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-
-HACK OPEN FONT LICENSE v2.0
-
-(Version 1.0 - 06 September 2015)
-
-(Version 2.0 - 27 September 2015)
-
-Copyright 2015 by Christopher Simpkins. All Rights Reserved.
-
-DEFINITIONS
-
-"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
-
-PERMISSION AND CONDITIONS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
-
-(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
-
-(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
-
-(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
-
-TERMINATION
-
-This license becomes null and void if any of the above conditions are not met.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-
-Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
-
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 BITSTREAM VERA LICENSE
 
@@ -100,7 +84,7 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
 
 Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org.</string>
 	<key>openTypeNameLicenseURL</key>
-	<string>https://github.com/chrissimpkins/Hack/blob/master/LICENSE.md</string>
+	<string>https://github.com/source-foundry/Hack/blob/master/LICENSE.md</string>
 	<key>openTypeNameManufacturer</key>
 	<string>Source Foundry</string>
 	<key>openTypeNameManufacturerURL</key>
@@ -112,7 +96,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameSampleText</key>
 	<string></string>
 	<key>openTypeNameUniqueID</key>
-	<string>ChristopherSimpkins: Hack: 2015</string>
+	<string>SourceFoundry: Hack: 2017</string>
 	<key>openTypeNameVersion</key>
 	<string>Version 3.000</string>
 	<key>openTypeOS2CodePageRanges</key>


### PR DESCRIPTION
The Hack license for work in the Hack project was modified to the MIT license.  Changes in this PR update the Hack license in the source files (built into OpenType tables of fonts), the LICENSE.md file, and the README.md file.  This change removes the reserved font name from the Hack typeface.

Full discussion was held in https://github.com/source-foundry/Hack/issues/271 

Public comment was open in the above thread x 1 month with very helpful feedback to reach the decision about this change.  All project lead authors invited to comment and have had opportunity to provide feedback on this change.  Change is approved and we will move forward with the licensing change.