### PR TITLE
Add CDNJS version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # Hack
 
 [![Build Status](https://travis-ci.org/source-foundry/Hack.svg?branch=master)](https://travis-ci.org/source-foundry/Hack) [![Contributors](https://img.shields.io/badge/contributors-121-orange.svg?style=flat)](https://github.com/source-foundry/Hack/blob/master/docs/CONTRIBUTORS.md)
+[![CDNJS](https://img.shields.io/cdnjs/v/hack-font.svg)](https://cdnjs.com/libraries/hack-font)
 
 Hack v3 is here!  [Click here to learn what's new](https://medium.com/source-words/hack-typeface-v3-6943991c1a80).
 


### PR DESCRIPTION
This badge will show the version on CDNJS

(@chrissimpkins edits below) ---

TODO (Chris and Samina to work on this):


- [ ] rebase changes on current master branch
- [ ] Update the web font documentation here https://github.com/source-foundry/Hack/blob/master/docs/WEBFONT_USAGE.md#hack-by-cdn
- [ ] Update the web font documentation here https://github.com/source-foundry/Hack#web-font-usage
- [ ] remove the cdnjs badge from the header completely or move it to the web font section of the README.md documentation.
- [x] Add @sufuf3 to the contributors list (@sufuf3 implemented the entire cdnjs redistribution effort and pushed this through the review process on the cdnjs side)
