### PR TITLE
Fallback mechanism for the woff/woff2 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The [alt-hack](https://github.com/source-foundry/alt-hack) library includes a (g
 
 We welcome contributions of new alternate glyph styles in the alt-hack repository.  Design something new that works well with rest of the typeface and submit a pull request to the alt-hack repository so that others can use it in their custom builds.
 
-Detailed build instructions are available on the [alt-hack repository README.md](https://github.com/source-foundry/alt-hack).
+Detailed build instructions are available on the [alt-hack repository README.md](https://github.com/source-foundry/alt-hack).  Font renaming instructions to support side-by-side installs with upstream Hack are available below.
 
 ### Line spacing adjustments
 
@@ -163,6 +163,12 @@ Detailed build instructions are available on the [alt-hack repository README.md]
 The following gist installs font-line and modifies line spacing for all desktop font files contained in the same directory:
 
 - [linespace.sh](https://gist.github.com/chrissimpkins/f39e85f5f157d839e46168de1b61a174) ([download .zip](https://gist.github.com/chrissimpkins/f39e85f5f157d839e46168de1b61a174/archive/f3f93dea87d64ddc4684a61cbc96ddf79d30824a.zip))
+
+### Install modified and unmodified versions of Hack on the same system
+
+If you modify the upstream Hack source or the released font binaries and would like to install your modified fonts on the same system with the Hack fonts as released here, you can use the [fontname.py Python script](https://github.com/chrissimpkins/fontname.py) to define a new font name in the binary files.  For example, you can install `Hack` on your platform along with a 15% UPM line spacing adjusted version as `Hack Fifteen`.  Modify default glyphs with those in our [alt-hack repository](https://github.com/source-foundry/alt-hack) or design your own and define your creation with any name that you'd like.  Following installation, your renamed fonts should show under the name that you define with the script so that you can switch between any of them as you need.
+
+Usage details and examples are provided on the fontname.py repository README.
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 
 # Hack
 
-[![Build Status](https://travis-ci.org/source-foundry/Hack.svg?branch=master)](https://travis-ci.org/source-foundry/Hack) [![Contributors](https://img.shields.io/badge/contributors-124-orange.svg?style=flat)](https://github.com/source-foundry/Hack/blob/master/docs/CONTRIBUTORS.md)
+[![GitHub release](https://img.shields.io/github/release/source-foundry/hack.svg?style=flat)](https://github.com/source-foundry/Hack/releases/latest)
+[![Build Status](https://travis-ci.org/source-foundry/Hack.svg?branch=master)](https://travis-ci.org/source-foundry/Hack)
+[![Contributors](https://img.shields.io/badge/contributors-126-orange.svg?style=flat)](https://github.com/source-foundry/Hack/blob/master/docs/CONTRIBUTORS.md)
+[![Join the chat at https://gitter.im/source-foundry/Hack](https://badges.gitter.im/source-foundry/Hack.svg)](https://gitter.im/source-foundry/Hack)
+[![Github All Releases](https://img.shields.io/github/downloads/source-foundry/hack/total.svg?style=flat)]()
+[![](https://data.jsdelivr.com/v1/package/npm/hack-font/badge?style=rounded)](https://www.jsdelivr.com/package/npm/hack-font)
 
 Hack v3 is here!  [Click here to learn what's new](https://medium.com/source-words/hack-typeface-v3-6943991c1a80).
 
@@ -73,7 +78,9 @@ Some Linux users may find that font rendering is improved on their distro with [
 
 ### Windows
 
-The [Hack Windows Installer](https://github.com/source-foundry/Hack-windows-installer/releases/latest) simplifies the installation process on the Windows platform.  The tool guides you through the installation process and addresses some common rendering issues that occur with font installs/updates on the Windows platform.  This tool is the recommended installation approach for Windows users.
+[![Hack Windows Installer](https://img.shields.io/badge/Windows-Installer-blue.svg?style=flat-square)](https://github.com/source-foundry/Hack-windows-installer/releases/latest)
+
+The [Hack Windows Installer](https://github.com/source-foundry/Hack-windows-installer/releases/latest) and simplifies the installation on the Windows platform.  The tool guides you through the installation process and addresses some common rendering issues that occur with font installs/updates on the Windows platform.  This tool is the recommended installation approach for Windows users.
 
 
 ### Chrome/ChromeOS
@@ -105,7 +112,14 @@ For installation issues with Hack packages, please contact the package maintaine
 
 ## Web font usage
 
-Hack is available in the woff and woff2 web font formats. Use the snippets below to include Hack on your web pages via CDN. **Bold** and *italic* styles are included by default and work out-of-the-box via the `<strong>` and `<em>` tags.
+Hack is available in the woff and woff2 web font formats. **Bold** and *italic* styles are included by default and work out-of-the-box via the `<strong>` and `<em>` tags.
+
+Hack is available through the jsDelivr and cdnjs CDN services:
+
+[![jsDelivr](https://img.shields.io/badge/jsDelivr-Hack_web_font_CDN-blue.svg?style=flat-square)](https://www.jsdelivr.com/package/npm/hack-font)
+[![cdnjs](https://img.shields.io/badge/cdnjs-Hack_web_font_CDN-blue.svg?style=flat-square)](https://cdnjs.com/libraries/hack-font)
+
+The following snippets provide examples of Hack web font use through the jsDelivr CDN.  Adjust the URL paths to those provided by cdnjs (click the link above to find the appropriate URL) to switch to the cdnjs CDN.
 
 #### 1. Add Hack to HTML
 
@@ -160,7 +174,7 @@ The following gist installs font-line and modifies line spacing for all desktop 
 
 ## Contributing
 
-We welcome contributions to Hack!  Please review our [CONTRIBUTING.md](CONTRIBUTING.md) document for additional details.
+We welcome contributions to Hack!  Please review our [CONTRIBUTING.md](CONTRIBUTING.md) document for details.
 
 
 ## Built With
@@ -184,7 +198,7 @@ Hack is built with the following free, open source projects:
 
 ## Acknowledgments
 
-We would like to acknowledge and thank the [jsDelivr](https://www.jsdelivr.com/) team for their excellent web font CDN service and outstanding Hack project support.
+We would like to acknowledge and thank the [jsDelivr](https://www.jsdelivr.com/) and [cdnjs](https://cdnjs.com) teams for their support of the Hack project through their free web font CDN services.  We greatly appreciate the tremendous support of open source software by the [Travis CI](https://travis-ci.org/) and [Semaphore CI](https://semaphoreci.com/) teams.  The Hack typeface software and our supporting software tooling are tested with free open source accounts provided by Travis and Semaphore, and we are incredibly grateful for this support. Lastly, a huge thanks go out to all of those who do the unrecognized work to get Hack out there to users so that it is easy to access, install, upgrade, and use.  There are redistribution package managers, review committee members, testers, and others across platforms/distros/applications who perform this thankless work.  Your efforts are much appreciated.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Some Linux users may find that font rendering is improved on their distro with [
 
 [![Hack Windows Installer](https://img.shields.io/badge/Windows-Installer-blue.svg?style=flat-square)](https://github.com/source-foundry/Hack-windows-installer/releases/latest)
 
-The [Hack Windows Installer](https://github.com/source-foundry/Hack-windows-installer/releases/latest) and simplifies the installation on the Windows platform.  The tool guides you through the installation process and addresses some common rendering issues that occur with font installs/updates on the Windows platform.  This tool is the recommended installation approach for Windows users.
+The [Hack Windows Installer](https://github.com/source-foundry/Hack-windows-installer/releases/latest) simplifies installation on the Windows platform.  The tool guides you through the installation process and addresses some common rendering issues that occur with font installs/updates on the Windows platform.  This tool is the recommended installation approach for Windows users.
 
 
 ### Chrome/ChromeOS

--- a/build-subsets.sh
+++ b/build-subsets.sh
@@ -135,19 +135,31 @@ fi
 # sfntwoff-zopfli installed
 if ! [ -f "$SFNTWOFF_BIN" ]
 	then
-	    echo "sfnt2woff-zopfli was not found on the path $SFNTWOFF_BIN.  Please install all build dependencies with 'make build-with-dependencies', then attempt your build again." 1>&2
-	    INSTALLFLAG=1
-else
-	echo "sfnt2woff-zopfli executable identified"
+	    if ! which sfnt2woff-zopfli
+	    	then
+	            echo "sfnt2woff-zopfli was not found on the path $SFNTWOFF_BIN.  Please install all build dependencies with 'make build-with-dependencies', then attempt your build again." 1>&2
+	            INSTALLFLAG=1
+	    else
+	    	SFNTWOFF_BIN="sfnt2woff-zopfli"
+	    	echo "sfnt2woff-zopfli executable identified"
+	    fi
+	else
+		echo "sfnt2woff-zopfli executable identified"
 fi
 
-# woff2 installed
+# woff2_compress installed
 if ! [ -f "$WOFF2_BIN" ]
 	then
-	    echo "woff2_compress was not found on the path $WOFF2_BIN.  Please install all build dependencies with 'make build-with-dependencies', then attempt your build again." 1>&2
-	    INSTALLFLAG=1
-else
-	echo "woff2_compress executable identified"
+	    if ! which woff2_compress
+	    	then
+	            echo "woff2_compress was not found on the path $SFNTWOFF_BIN.  Please install all build dependencies with 'make build-with-dependencies', then attempt your build again." 1>&2
+	            INSTALLFLAG=1
+	    else
+	    	WOFF2_BIN="woff2_compress"
+	    	echo "woff2_compress executable identified"
+	    fi
+	else
+		echo "woff2_compress executable identified"
 fi
 
 # if any of the dependency installs failed, exit and do not attempt build, notify user

--- a/build-woff.sh
+++ b/build-woff.sh
@@ -93,6 +93,13 @@ if [ "$1" = "--install-dependencies" ]
 		cd "$CUR_DIR" || exit 1
 fi
 
+# If the binary is not found, look if it is installed system-wide
+if [ ! -x "$SFNTWOFF_BIN" ]; then
+	SFNTWOFF_SYSWIDE=$(command -pv sfnt2woff-zopfli)
+	if [ -x "$SFNTWOFF_SYSWIDE" ]; then
+		SFNTWOFF_BIN=$SFNTWOFF_SYSWIDE
+	fi
+fi
 
 if [ -f "$SFNTWOFF_BIN" ]; then
 	echo "Beginning web font build with $SFNTWOFF"

--- a/build-woff2.sh
+++ b/build-woff2.sh
@@ -26,7 +26,6 @@ INST="$HOME/woff2"
 # woff2 executable path
 WOFF2_BIN="$BUILD/woff2/woff2_compress"
 
-
 # The font build directory paths and file paths for the woff builds
 TTF_BUILD="build/ttf"
 WOFF_BUILD="build/web/fonts"
@@ -85,6 +84,13 @@ if [ "$1" = "--install-dependencies" ]
 		cd "$CUR_DIR" || exit 1
 fi
 
+# If the binary is not found, look if it is installed system-wide
+if [ ! -x "$WOFF2_BIN" ]; then
+	WOFF2_SYSWIDE=$(command -pv woff2_compress)
+	if [ -x "$WOFF2_SYSWIDE" ]; then
+		WOFF2_BIN="$WOFF2_SYSWIDE"
+	fi
+fi
 
 if [ -f "$WOFF2_BIN" ]; then
 	echo "Beginning web font build with $WOFF2_BIN"

--- a/docs/WEBFONT_USAGE.md
+++ b/docs/WEBFONT_USAGE.md
@@ -6,8 +6,10 @@ You can view the rendering of the web fonts at a range of sizes on the [Hack web
 
 #### Hack by CDN
 
-Thanks to the generous gang at [jsDelivr](https://github.com/jsdelivr/jsdelivr), you can use a CDN to include Hack on your site with a single stylesheet link in the head of your HTML files.  There is no need to download font files from the repository or serve them from your web server.  Instructions for web font CDN use are available on our README page.
+Thanks to the generous gangs at [jsDelivr](https://github.com/jsdelivr/jsdelivr) and [cdnjs](https://www.cdnjs.com), you can use a CDN to include Hack on your site with a single stylesheet link in the head of your HTML files.  There is no need to download font files from the repository or serve them from your web server.  Instructions for web font CDN use are available on our README page and you can use either of the following CDN:
 
+[![jsDelivr](https://img.shields.io/badge/jsDelivr-Hack_web_font_CDN-blue.svg?style=flat-square)](https://www.jsdelivr.com/package/npm/hack-font)
+[![cdnjs](https://img.shields.io/badge/cdnjs-Hack_web_font_CDN-blue.svg?style=flat-square)](https://cdnjs.com/libraries/hack-font)
 
 #### Host Hack Font Files on Your Server
 
@@ -63,7 +65,7 @@ Then style your text by including `Hack` in the appropriate `font-family` proper
 
 ```css
 code {
-	font-family: Hack, monospace;
+    font-family: Hack, monospace;
 }
 ```
 


### PR DESCRIPTION
If sfnt2woff-zopfli and woff2_compress binaries are not found in the
installation directory targeted when the scripts are called with
--install-dependencies, then look if the binaries are installed
system-wide (i.e., in the $PATH).

IR #395.