### PR TITLE
Checksum script for SHA1 hash testing of OpenType tables

### DIFF
--- a/tools/scripts/checksum/checksum.py
+++ b/tools/scripts/checksum/checksum.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#----------------------------------------------------------------
+# checksum.py
+#  A SHA1 hash checksum list generator for fonts and fontTools
+#  XML dumps of font OpenType table data
+#
+# Copyright 2018 Christopher Simpkins
+# MIT License
+#
+# Usage: checksum.py (options) [file path 1]...[file path n]
+#
+# Dependencies: Python fontTools library
+#----------------------------------------------------------------
+
+import argparse
+import hashlib
+import os
+import sys
+
+from os.path import basename
+
+from fontTools.ttLib import TTFont
+
+
+def main(filepaths, stdout_write=False, use_ttx=False, include_tables=None, exclude_tables=None, do_not_cleanup=False):
+    checksum_dict = {}
+    for path in filepaths:
+        if not os.path.exists(path):
+            sys.stderr.write("[checksum.py] ERROR: " + path + " is not a valid file path" + os.linesep)
+            sys.exit(1)
+
+        if use_ttx:
+            # append a .ttx extension to existing extension to maintain data about the binary that
+            # was used to generate the .ttx XML dump.  This creates unique checksum path values for
+            # paths that would otherwise not be unique with a file extension replacement with .ttx
+            # An example is woff and woff2 web font files that share the same base file name:
+            #
+            #  coolfont-regular.woff  ==> coolfont-regular.ttx
+            #  coolfont-regular.woff2 ==> coolfont-regular.ttx  (KAPOW! checksum data lost as this would overwrite dict value)
+            temp_ttx_path = path + ".ttx"
+
+            tt = TTFont(path)
+            tt.saveXML(temp_ttx_path, newlinestr="\n", skipTables=exclude_tables, tables=include_tables)
+            checksum_path = temp_ttx_path
+        else:
+            if include_tables is not None:
+                sys.stderr.write("[checksum.py] -i and --include are not supported for font binary filepaths. \
+                    Use these flags for checksums with the --ttx flag.")
+                sys.exit(1)
+            if exclude_tables is not None:
+                sys.stderr.write("[checksum.py] -e and --exclude are not supported for font binary filepaths. \
+                    Use these flags for checksums with the --ttx flag.")
+                sys.exit(1)
+            checksum_path = path
+
+        file_contents = read_binary(checksum_path)
+
+        # store SHA1 hash data and associated file path basename in the checksum_dict dictionary
+        checksum_dict[basename(checksum_path)] = hashlib.sha1(file_contents).hexdigest()
+
+        # remove temp ttx files when present
+        if use_ttx and do_not_cleanup is False:
+            os.remove(temp_ttx_path)
+
+    # generate the checksum list string for writes
+    checksum_out_data = ""
+    for key in checksum_dict.keys():
+        checksum_out_data += checksum_dict[key] + "  " + key + "\n"
+
+    # write to stdout stream or file based upon user request (default = file write)
+    if stdout_write:
+        sys.stdout.write(checksum_out_data)
+    else:
+        checksum_report_filepath = "checksum.txt"
+        with open(checksum_report_filepath, "w") as file:
+            file.write(checksum_out_data)
+
+
+def read_binary(filepath):
+    with open(filepath, mode='rb') as file:
+        return file.read()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog="checksum.py")
+    parser.add_argument("-t", "--ttx", help="Calculate from ttx file", action="store_true")
+    parser.add_argument("-s", "--stdout", help="Write output to stdout stream", action="store_true")
+    parser.add_argument("-n", "--noclean", help="Do not discard *.ttx files used to calculate SHA1 hashes", action="store_true")
+    parser.add_argument("filepaths", nargs="+", help="One or more file paths to font binary files")
+
+    parser.add_argument("-i", "--include", action="append", help="Included OpenType tables for ttx data dump")
+    parser.add_argument("-e", "--exclude", action="append", help="Excluded OpenType tables for ttx data dump")
+
+    args = parser.parse_args(sys.argv[1:])
+
+    main(args.filepaths, stdout_write=args.stdout, use_ttx=args.ttx, do_not_cleanup=args.noclean, include_tables=args.include, exclude_tables=args.exclude)

--- a/tools/scripts/checksum/checksum.py
+++ b/tools/scripts/checksum/checksum.py
@@ -16,6 +16,9 @@
 #
 # Usage: checksum.py (options) [file path 1]...[file path n]
 #
+#   `file path` should be defined as a path to a font file for all use cases except with use of -c/--check.
+#   With the -c/--check option, use one or more file paths to checksum files
+#
 # Options:
 #   -h, --help          Help
 #   -t, --ttx           Calculate SHA1 hash values from ttx dump of XML (default = font binary)

--- a/tools/scripts/checksum/checksum.py
+++ b/tools/scripts/checksum/checksum.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#----------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------
 # checksum.py
 #  A SHA1 hash checksum list generator for fonts and fontTools
-#  XML dumps of font OpenType table data
+#  XML dumps of font OpenType table data + checksum testing
+#  script
 #
 # Copyright 2018 Christopher Simpkins
 # MIT License
 #
+# Dependencies: Python fontTools library
+#
 # Usage: checksum.py (options) [file path 1]...[file path n]
 #
-# Dependencies: Python fontTools library
-#----------------------------------------------------------------
+# Options:
+#   -h, --help          Help
+#   -t, --ttx           Calculate SHA1 hash values from ttx dump of XML (default = font binary)
+#   -s, --stdout        Stream to standard output stream (default = write to disk as 'checksum.txt')
+#   -c, --check         Test SHA1 checksum values against a valid checksum file
+#
+# Options, --ttx only:
+#   -e, --exclude       Excluded OpenType table (may be used more than once, mutually exclusive with -i)
+#   -i, --include       Included OpenType table (may be used more than once, mutually exclusive with -e)
+#   -n, --noclean       Do not discard .ttx files that are used to calculate SHA1 hashes
+#-------------------------------------------------------------------------------------------------------
 
 import argparse
 import hashlib
@@ -24,7 +36,7 @@ from os.path import basename
 from fontTools.ttLib import TTFont
 
 
-def main(filepaths, stdout_write=False, use_ttx=False, include_tables=None, exclude_tables=None, do_not_cleanup=False):
+def write_checksum(filepaths, stdout_write=False, use_ttx=False, include_tables=None, exclude_tables=None, do_not_cleanup=False):
     checksum_dict = {}
     for path in filepaths:
         if not os.path.exists(path):
@@ -42,6 +54,8 @@ def main(filepaths, stdout_write=False, use_ttx=False, include_tables=None, excl
             temp_ttx_path = path + ".ttx"
 
             tt = TTFont(path)
+            # important to keep the newlinestr value defined here as hash values will change across platforms
+            # if platform specific newline values are assumed
             tt.saveXML(temp_ttx_path, newlinestr="\n", skipTables=exclude_tables, tables=include_tables)
             checksum_path = temp_ttx_path
         else:
@@ -55,7 +69,7 @@ def main(filepaths, stdout_write=False, use_ttx=False, include_tables=None, excl
                 sys.exit(1)
             checksum_path = path
 
-        file_contents = read_binary(checksum_path)
+        file_contents = _read_binary(checksum_path)
 
         # store SHA1 hash data and associated file path basename in the checksum_dict dictionary
         checksum_dict[basename(checksum_path)] = hashlib.sha1(file_contents).hexdigest()
@@ -78,7 +92,48 @@ def main(filepaths, stdout_write=False, use_ttx=False, include_tables=None, excl
             file.write(checksum_out_data)
 
 
-def read_binary(filepath):
+def check_checksum(filepaths):
+    check_failed = False
+    for path in filepaths:
+        if not os.path.exists(path):
+            sys.stderr.write("[checksum.py] ERROR: " + filepath + " is not a valid filepath" + os.linesep)
+            sys.exit(1)
+
+        with open(path, mode='r') as file:
+            for line in file.readlines():
+                cleaned_line = line.rstrip()
+                line_list = cleaned_line.split(" ")
+                # eliminate empty strings parsed from > 1 space characters
+                line_list = list(filter(None, line_list))
+                if len(line_list) == 2:
+                    expected_sha1 = line_list[0]
+                    test_path = line_list[1]
+                else:
+                    sys.stderr.write("[checksum.py] ERROR: failed to parse checksum file values" + os.linesep)
+                    sys.exit(1)
+
+                if not os.path.exists(test_path):
+                    print(test_path + ": Filepath is not valid, ignored")
+                else:
+                    file_contents = _read_binary(test_path)
+                    observed_sha1 = hashlib.sha1(file_contents).hexdigest()
+                    if observed_sha1 == expected_sha1:
+                        print(test_path + ": OK")
+                    else:
+                        print("-" * 80)
+                        print(test_path + ": === FAIL ===")
+                        print("Expected vs. Observed:")
+                        print(expected_sha1)
+                        print(observed_sha1)
+                        print("-" * 80)
+                        check_failed = True
+
+    # exit with status code 1 if any fails detected across all tests in the check
+    if check_failed is True:
+        sys.exit(1)
+
+
+def _read_binary(filepath):
     with open(filepath, mode='rb') as file:
         return file.read()
 
@@ -88,6 +143,7 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--ttx", help="Calculate from ttx file", action="store_true")
     parser.add_argument("-s", "--stdout", help="Write output to stdout stream", action="store_true")
     parser.add_argument("-n", "--noclean", help="Do not discard *.ttx files used to calculate SHA1 hashes", action="store_true")
+    parser.add_argument("-c", "--check", help="Verify checksum values vs. files", action="store_true")
     parser.add_argument("filepaths", nargs="+", help="One or more file paths to font binary files")
 
     parser.add_argument("-i", "--include", action="append", help="Included OpenType tables for ttx data dump")
@@ -95,4 +151,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args(sys.argv[1:])
 
-    main(args.filepaths, stdout_write=args.stdout, use_ttx=args.ttx, do_not_cleanup=args.noclean, include_tables=args.include, exclude_tables=args.exclude)
+    if args.check is True:
+        check_checksum(args.filepaths)
+    else:
+        write_checksum(args.filepaths, stdout_write=args.stdout, use_ttx=args.ttx, do_not_cleanup=args.noclean, include_tables=args.include, exclude_tables=args.exclude)

--- a/tools/scripts/checksum/checksum.py
+++ b/tools/scripts/checksum/checksum.py
@@ -101,7 +101,7 @@ def check_checksum(filepaths):
     check_failed = False
     for path in filepaths:
         if not os.path.exists(path):
-            sys.stderr.write("[checksum.py] ERROR: " + filepath + " is not a valid filepath" + os.linesep)
+            sys.stderr.write("[checksum.py] ERROR: " + path + " is not a valid filepath" + os.linesep)
             sys.exit(1)
 
         with open(path, mode='r') as file:

--- a/tools/scripts/checksum/checksum.py
+++ b/tools/scripts/checksum/checksum.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#------------------------------------------------------------------------------------------------------
+#----------------------------------------------------------------------------------------------------------
 # checksum.py
 #  A SHA1 hash checksum list generator for fonts and fontTools
 #  XML dumps of font OpenType table data + checksum testing
@@ -10,21 +10,23 @@
 # Copyright 2018 Christopher Simpkins
 # MIT License
 #
-# Dependencies: Python fontTools library
+# Dependencies:
+#   - Python fontTools library
+#   - Python 3 interpreter
 #
 # Usage: checksum.py (options) [file path 1]...[file path n]
 #
 # Options:
 #   -h, --help          Help
 #   -t, --ttx           Calculate SHA1 hash values from ttx dump of XML (default = font binary)
-#   -s, --stdout        Stream to standard output stream (default = write to disk as 'checksum.txt')
+#   -s, --stdout        Stream to standard output stream (default = write to working dir as 'checksum.txt')
 #   -c, --check         Test SHA1 checksum values against a valid checksum file
 #
 # Options, --ttx only:
 #   -e, --exclude       Excluded OpenType table (may be used more than once, mutually exclusive with -i)
 #   -i, --include       Included OpenType table (may be used more than once, mutually exclusive with -e)
 #   -n, --noclean       Do not discard .ttx files that are used to calculate SHA1 hashes
-#-------------------------------------------------------------------------------------------------------
+#-----------------------------------------------------------------------------------------------------------
 
 import argparse
 import hashlib


### PR DESCRIPTION
@paride @spstarr @fabiangreffrath

This is an approach that might address the issue with testing upstream/downstream dependency divergence during the build process as your build dependency versions begin to change from those here.  This is a general purpose script and will serve for other font projects as well if you happen to maintain anything other than Hack.  My goal was to produce something that gives you a simple YES/NO answer about whether your build with different tooling versions should render the same as fonts built with upstream tooling versions across the entire build toolchain (including dependencies of dependencies).  

This Python script adds the capacity to perform SHA1 checksum generation and testing across specific OT tables in the font binaries and generate checksums for those relevant tables, excluding tables that do not affect renders and are modified in a time dependent fashion (certain tables are time stamped with times and checksum values dependent upon compile time).  My thought is that we can publish a checksum file with these SHA1 hashes across all desktop (*.ttf) and web (*.woff/*woff2) fonts with each release build.  The script makes valid checksum files that can be tested with `sha1sum` on your distros or this script can be used directly with its own `-c` flag to test the values against the data contained in fonts that you build.  It ignores missing file paths specified in the checksum file and returns a non-zero exit status code if it finds checksum values that do not match expected values for existing file paths.

It will look like something like this on your end for desktop fonts at the moment:

```
# produce your own set of XML dumps of select OT tables after your builds to use for checksum tests
$ cd build/ttf
$ [path to]/checksum.py --exclude head --exclude DSIG --stdout --noclean *.ttf > /dev/null

# pull the upstream checksum file (or perhaps this is the location for our upstream writes of the file?)
$ curl -L -O [path to checksum file in upstream repository]

# perform the checksum checks
$ ./checksum.py -c checksum.txt

OR 

$ sha1sum -c checksum.txt

# cleanup
$ rm *.ttx
```

and for web fonts:

```
# produce your own set of XML dumps of select OT tables after your build to use for checksum tests
$ cd build/web/fonts
$ [path to]/checksum.py --exclude head --exclude DSIG --stdout --noclean *.woff *.woff2 > /dev/null

# pull the upstream checksum file (or perhaps this is the location for our upstream writes of the file?)
$ curl -L -O [path to checksum file in upstream repository]

# perform the checksum checks
$ ./checksum.py -c checksum.txt

OR 

$ sha1sum -c checksum.txt

# cleanup
$ rm *.ttx
```

You can then delete all *.ttx files that you generated for the testing above.  Exit status code of 0 means that you are building what we are building upstream with respect to tables that affect rendering.  Exit status code 1 means that you are building tables that differ from the upstream.  This information will be important for the build tooling authors to know in some cases and we would greatly appreciate being made aware of these issues so that we can take this into account when we consider changes to the upstream build versions as well.  Always happy to help troubleshoot differences that you find in your builds. This script and the script that @anthrotype contributed to the repo will provide a solid approach to examine these changes very easily.  That doesn't mean that there will be a simple interpretation of what they mean but identification of changes in the binary files is no longer as time consuming as it once was and we can offer this to downstream repos.

ttx is part of the fontTools library so there is no new dependency.  fontTools and Python3 interpreter are the only dependencies involved here so there is nothing new to approve.  This script will be merged into the Hack repository and distributed with your source pulls.  

Let me know if this works for you and whether there are any modifications to the script that we should make.  If this works, let us know where it is best to store these checksum files.  It would be easiest and most useful upstream to place them in a repository directory so that we can write them out during testing builds in order to git diff the SHA1 hashes for unexpected changes as we make changes here.  If better as a new file in our releases, we can certainly entertain that idea as well.  My plan is to create a new make target for the tasks on our end to create the checksum files.  We can also add a target to test the checksum files once we identify a location for the checksum files.

TODO:

- [ ] add documentation Markdown page for downstream repos to use as a reference for analysis of builds from source with the `checksum.py` and `ttdiff.sh` tools that will be included in this repo