### PR TITLE
[U+0028, U+0029] Made parentheses `(` and `)` rounder

### DIFF
--- a/source/Hack-Bold.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenleft.glif
@@ -11,13 +11,13 @@
       <point x="254" y="1177"/>
       <point x="531" y="1531"/>
       <point x="987" y="1636" type="curve" name="at01"/>
-      <point x="987" y="1446" type="line"/>
-      <point x="717" y="1334"/>
+      <point x="987" y="1421" type="line"/>
+      <point x="717" y="1309"/>
       <point x="519" y="1081"/>
       <point x="519" y="683" type="curve" smooth="yes" name="dh02"/>
       <point x="519" y="285"/>
-      <point x="717" y="27"/>
-      <point x="987" y="-85" type="curve" name="av01"/>
+      <point x="717" y="52"/>
+      <point x="987" y="-60" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Bold.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenleft.glif
@@ -4,32 +4,20 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point x="596" y="-270" type="line" name="hr00"/>
-      <point x="497" y="-127"/>
-      <point x="416" y="23"/>
-      <point x="360" y="186" type="curve" smooth="yes"/>
-      <point x="309" y="336"/>
-      <point x="283" y="488"/>
-      <point x="283" y="643" type="curve" name="dh01" smooth="yes"/>
-      <point x="283" y="797"/>
-      <point x="309" y="950"/>
-      <point x="361" y="1101" type="curve" smooth="yes"/>
-      <point x="412" y="1248"/>
-      <point x="484" y="1393"/>
-      <point x="596" y="1554" type="curve" name="at01"/>
-      <point x="824" y="1554" type="line"/>
-      <point x="739" y="1399"/>
-      <point x="672" y="1244"/>
-      <point x="628" y="1091" type="curve" smooth="yes"/>
-      <point x="585" y="943"/>
-      <point x="564" y="794"/>
-      <point x="564" y="643" type="curve" name="dh02" smooth="yes"/>
-      <point x="564" y="494"/>
-      <point x="585" y="345"/>
-      <point x="628" y="196" type="curve" smooth="yes"/>
-      <point x="671" y="45"/>
-      <point x="737" y="-111"/>
-      <point x="824" y="-270" type="curve" name="av01"/>
+      <point x="987" y="-270" type="line" name="hr00"/>
+      <point x="531" y="-165"/>
+      <point x="254" y="189"/>
+      <point x="254" y="683" type="curve" smooth="yes" name="dh01"/>
+      <point x="254" y="1177"/>
+      <point x="531" y="1531"/>
+      <point x="987" y="1636" type="curve" name="at01"/>
+      <point x="987" y="1446" type="line"/>
+      <point x="717" y="1334"/>
+      <point x="519" y="1081"/>
+      <point x="519" y="683" type="curve" smooth="yes" name="dh02"/>
+      <point x="519" y="285"/>
+      <point x="717" y="27"/>
+      <point x="987" y="-85" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Bold.ufo/glyphs/parenright.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenright.glif
@@ -4,32 +4,20 @@
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point x="409" y="-270" type="line" name="hr00"/>
-      <point x="496" y="-111"/>
-      <point x="562" y="45"/>
-      <point x="605" y="196" type="curve" smooth="yes"/>
-      <point x="648" y="345"/>
-      <point x="669" y="494"/>
-      <point x="669" y="643" type="curve" name="dh01" smooth="yes"/>
-      <point x="669" y="794"/>
-      <point x="648" y="943"/>
-      <point x="605" y="1091" type="curve" smooth="yes"/>
-      <point x="562" y="1238"/>
-      <point x="498" y="1393"/>
-      <point x="409" y="1554" type="curve" name="at01"/>
-      <point x="637" y="1554" type="line"/>
-      <point x="743" y="1401"/>
-      <point x="822" y="1250"/>
-      <point x="873" y="1101" type="curve" smooth="yes"/>
-      <point x="925" y="949"/>
-      <point x="950" y="792"/>
-      <point x="950" y="641" type="curve" name="dh02" smooth="yes"/>
-      <point x="950" y="488"/>
-      <point x="924" y="336"/>
-      <point x="873" y="186" type="curve" smooth="yes"/>
-      <point x="820" y="30"/>
-      <point x="742" y="-117"/>
-      <point x="637" y="-270" type="curve" name="av01"/>
+      <point x="244" y="-85" type="line" name="hr00"/>
+      <point x="514" y="27"/>
+      <point x="717" y="285"/>
+      <point x="717" y="683" type="curve" smooth="yes" name="dh01"/>
+      <point x="717" y="1081.06"/>
+      <point x="514" y="1334"/>
+      <point x="244" y="1446" type="curve" name="at01"/>
+      <point x="244" y="1636" type="line"/>
+      <point x="700" y="1531"/>
+      <point x="979" y="1177"/>
+      <point x="979" y="683" type="curve" smooth="yes" name="dh02"/>
+      <point x="979" y="189"/>
+      <point x="700" y="-165"/>
+      <point x="244" y="-270" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-BoldItalic.ufo/glyphs/parenleft.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/parenleft.glif
@@ -4,29 +4,20 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point x="440" y="-270" type="line" name="hr00"/>
-      <point x="388" y="-161"/>
-      <point x="346" y="-49"/>
-      <point x="318" y="67" type="curve" smooth="yes"/>
-      <point x="291" y="176"/>
-      <point x="278" y="284"/>
-      <point x="278" y="393" type="curve" name="dh01" smooth="yes"/>
-      <point x="278" y="784"/>
-      <point x="448" y="1164"/>
-      <point x="794" y="1554" type="curve" name="at01"/>
-      <point x="1019" y="1554" type="line"/>
-      <point x="863" y="1345"/>
-      <point x="746" y="1140"/>
-      <point x="669" y="941" type="curve" smooth="yes"/>
-      <point x="591" y="740"/>
-      <point x="552" y="541"/>
-      <point x="552" y="346" type="curve" name="dh02" smooth="yes"/>
-      <point x="552" y="251"/>
-      <point x="561" y="153"/>
-      <point x="580" y="50" type="curve" smooth="yes"/>
-      <point x="600" y="-58"/>
-      <point x="629" y="-165"/>
-      <point x="665" y="-270" type="curve" name="av01"/>
+      <point x="897" y="-285" type="line" name="hr00"/>
+      <point x="365" y="-175"/>
+      <point x="338.521" y="483.468"/>
+      <point x="370" y="683" type="curve" smooth="yes" name="dh01"/>
+      <point x="432" y="1076"/>
+      <point x="651" y="1555"/>
+      <point x="1206" y="1651" type="curve" name="at01"/>
+      <point x="1176" y="1478" type="line"/>
+      <point x="834" y="1375"/>
+      <point x="697.385" y="1073.1"/>
+      <point x="635" y="683" type="curve" smooth="yes" name="dh02"/>
+      <point x="572.173" y="290.132"/>
+      <point x="660" y="-23"/>
+      <point x="925" y="-112" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-BoldItalic.ufo/glyphs/parenright.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/parenright.glif
@@ -4,29 +4,20 @@
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point x="243" y="-270" type="line" name="hr00"/>
-      <point x="554" y="147"/>
-      <point x="710" y="547"/>
-      <point x="710" y="939" type="curve" name="dh01" smooth="yes"/>
-      <point x="710" y="1034"/>
-      <point x="701" y="1131"/>
-      <point x="682" y="1235" type="curve" smooth="yes"/>
-      <point x="663" y="1338"/>
-      <point x="634" y="1445"/>
-      <point x="597" y="1554" type="curve" name="at01"/>
-      <point x="822" y="1554" type="line"/>
-      <point x="877" y="1439"/>
-      <point x="917" y="1327"/>
-      <point x="944" y="1218" type="curve" smooth="yes"/>
-      <point x="971" y="1107"/>
-      <point x="984" y="999"/>
-      <point x="984" y="892" type="curve" name="dh02" smooth="yes"/>
-      <point x="984" y="697"/>
-      <point x="942" y="505"/>
-      <point x="855" y="310" type="curve" smooth="yes"/>
-      <point x="770" y="118"/>
-      <point x="640" y="-75"/>
-      <point x="468" y="-270" type="curve" name="av01"/>
+      <point x="552" y="1650" type="line" name="hr00"/>
+      <point x="1083.65" y="1538.33"/>
+      <point x="1107.11" y="879.86"/>
+      <point x="1075.01" y="680.428" type="curve" smooth="yes" name="dh01"/>
+      <point x="1011.78" y="287.624"/>
+      <point x="819" y="-176"/>
+      <point x="245.025" y="-285.045" type="curve" name="at01"/>
+      <point x="273" y="-112" type="line"/>
+      <point x="567" y="-35"/>
+      <point x="746.403" y="291.089"/>
+      <point x="810.01" y="680.989" type="curve" smooth="yes" name="dh02"/>
+      <point x="874.069" y="1073.66"/>
+      <point x="780" y="1360"/>
+      <point x="524.551" y="1477.07" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Italic.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Italic.ufo/glyphs/parenleft.glif
@@ -4,29 +4,20 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point x="426" y="-270" type="line" name="hr00"/>
-      <point x="319" y="-15"/>
-      <point x="273" y="179"/>
-      <point x="273" y="381" type="curve" name="dh01" smooth="yes"/>
-      <point x="273" y="576"/>
-      <point x="315" y="777"/>
-      <point x="402" y="978" type="curve" smooth="yes"/>
-      <point x="486" y="1174"/>
-      <point x="612" y="1366"/>
-      <point x="783" y="1554" type="curve" name="at01"/>
-      <point x="942" y="1554" type="line"/>
-      <point x="785" y="1351"/>
-      <point x="668" y="1156"/>
-      <point x="587" y="948" type="curve" smooth="yes"/>
-      <point x="507" y="744"/>
-      <point x="467" y="541"/>
-      <point x="467" y="340" type="curve" name="dh02" smooth="yes"/>
-      <point x="467" y="235"/>
-      <point x="478" y="142"/>
-      <point x="497" y="43" type="curve" smooth="yes"/>
-      <point x="518" y="-65"/>
-      <point x="546" y="-162"/>
-      <point x="586" y="-270" type="curve" name="av01"/>
+      <point x="904" y="-270" type="line" name="hr00"/>
+      <point x="372" y="-160"/>
+      <point x="369.521" y="483.468"/>
+      <point x="401" y="683" type="curve" smooth="yes" name="dh01"/>
+      <point x="463" y="1076"/>
+      <point x="684" y="1520"/>
+      <point x="1206" y="1636" type="curve" name="at01"/>
+      <point x="1183" y="1493" type="line"/>
+      <point x="780" y="1312"/>
+      <point x="642.385" y="1073.1"/>
+      <point x="580" y="683" type="curve" smooth="yes" name="dh02"/>
+      <point x="517.173" y="290.132"/>
+      <point x="620" y="0"/>
+      <point x="927" y="-127" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Italic.ufo/glyphs/parenright.glif
+++ b/source/Hack-Italic.ufo/glyphs/parenright.glif
@@ -4,32 +4,20 @@
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point x="320" y="-270" type="line" name="hr00"/>
-      <point x="478" y="-69"/>
-      <point x="597" y="133"/>
-      <point x="676" y="336" type="curve" smooth="yes"/>
-      <point x="756" y="540"/>
-      <point x="795" y="743"/>
-      <point x="795" y="940" type="curve" name="dh01" smooth="yes"/>
-      <point x="795" y="1039"/>
-      <point x="785" y="1142"/>
-      <point x="766" y="1241" type="curve" smooth="yes"/>
-      <point x="747" y="1338"/>
-      <point x="716" y="1446"/>
-      <point x="676" y="1554" type="curve" name="at01"/>
-      <point x="836" y="1554" type="line"/>
-      <point x="889" y="1427"/>
-      <point x="927" y="1312"/>
-      <point x="952" y="1209" type="curve" smooth="yes"/>
-      <point x="977" y="1104"/>
-      <point x="989" y="1008"/>
-      <point x="989" y="904" type="curve" name="dh02" smooth="yes"/>
-      <point x="989" y="709"/>
-      <point x="947" y="507"/>
-      <point x="860" y="307" type="curve" smooth="yes"/>
-      <point x="772" y="104"/>
-      <point x="647" y="-85"/>
-      <point x="479" y="-270" type="curve" name="av01"/>
+      <point x="545" y="1635" type="line" name="hr00"/>
+      <point x="1076.65" y="1523.33"/>
+      <point x="1077.11" y="879.86"/>
+      <point x="1045.01" y="680.428" type="curve" smooth="yes" name="dh01"/>
+      <point x="981.778" y="287.624"/>
+      <point x="759.387" y="-155.68"/>
+      <point x="237.025" y="-270.045" type="curve" name="at01"/>
+      <point x="260.475" y="-127.115" type="line"/>
+      <point x="664.039" y="52.6201"/>
+      <point x="802.403" y="291.089"/>
+      <point x="866.01" y="680.989" type="curve" smooth="yes" name="dh02"/>
+      <point x="930.069" y="1073.66"/>
+      <point x="828.153" y="1364.11"/>
+      <point x="521.551" y="1492.07" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenleft.glif
@@ -4,29 +4,20 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point x="595" y="-270" type="line" name="hr00"/>
-      <point x="491" y="-105"/>
-      <point x="419" y="43"/>
-      <point x="370" y="194" type="curve" smooth="yes"/>
-      <point x="321" y="345"/>
-      <point x="296" y="495"/>
-      <point x="296" y="643" type="curve" name="dh01" smooth="yes"/>
-      <point x="296" y="790"/>
-      <point x="321" y="940"/>
-      <point x="370" y="1092" type="curve" smooth="yes"/>
-      <point x="421" y="1245"/>
-      <point x="492" y="1394"/>
-      <point x="595" y="1554" type="curve" name="at01"/>
-      <point x="755" y="1554" type="line"/>
-      <point x="660" y="1393"/>
-      <point x="600" y="1249"/>
-      <point x="557" y="1100" type="curve" smooth="yes"/>
-      <point x="512" y="943"/>
-      <point x="491" y="796"/>
-      <point x="491" y="643" type="curve" name="dh02" smooth="yes"/>
-      <point x="491" y="334"/>
-      <point x="576" y="41"/>
-      <point x="755" y="-270" type="curve" name="av01"/>
+      <point x="947" y="-270" type="line" name="hr00"/>
+      <point x="531" y="-165"/>
+      <point x="293" y="189"/>
+      <point x="293" y="683" type="curve" smooth="yes" name="dh01"/>
+      <point x="293" y="1177"/>
+      <point x="531" y="1531"/>
+      <point x="947" y="1636" type="curve" name="at01"/>
+      <point x="947" y="1493" type="line"/>
+      <point x="651" y="1339"/>
+      <point x="477" y="1081"/>
+      <point x="477" y="683" type="curve" smooth="yes" name="dh02"/>
+      <point x="477" y="285"/>
+      <point x="651" y="27"/>
+      <point x="947" y="-127" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenleft.glif
@@ -11,13 +11,13 @@
       <point x="293" y="1177"/>
       <point x="531" y="1531"/>
       <point x="947" y="1636" type="curve" name="at01"/>
-      <point x="947" y="1493" type="line"/>
-      <point x="651" y="1339"/>
+      <point x="947" y="1468" type="line"/>
+      <point x="651" y="1324"/>
       <point x="477" y="1081"/>
       <point x="477" y="683" type="curve" smooth="yes" name="dh02"/>
       <point x="477" y="285"/>
-      <point x="651" y="27"/>
-      <point x="947" y="-127" type="curve" name="av01"/>
+      <point x="651" y="42"/>
+      <point x="947" y="-102" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/parenright.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenright.glif
@@ -4,32 +4,20 @@
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point x="478" y="-270" type="line" name="hr00"/>
-      <point x="566" y="-116"/>
-      <point x="632" y="37"/>
-      <point x="677" y="189" type="curve" smooth="yes"/>
-      <point x="718" y="332"/>
-      <point x="742" y="487"/>
-      <point x="742" y="643" type="curve" name="dh01" smooth="yes"/>
-      <point x="742" y="792"/>
-      <point x="720" y="949"/>
-      <point x="677" y="1098" type="curve" smooth="yes"/>
-      <point x="636" y="1241"/>
-      <point x="570" y="1395"/>
-      <point x="478" y="1554" type="curve" name="at01"/>
-      <point x="638" y="1554" type="line"/>
-      <point x="740" y="1396"/>
-      <point x="815" y="1242"/>
-      <point x="863" y="1092" type="curve" smooth="yes"/>
-      <point x="912" y="940"/>
-      <point x="937" y="790"/>
-      <point x="937" y="643" type="curve" name="dh02" smooth="yes"/>
-      <point x="937" y="494"/>
-      <point x="912" y="344"/>
-      <point x="863" y="192" type="curve" smooth="yes"/>
-      <point x="814" y="41"/>
-      <point x="739" y="-113"/>
-      <point x="638" y="-270" type="curve" name="av01"/>
+      <point x="286" y="-127" type="line" name="hr00"/>
+      <point x="582" y="27"/>
+      <point x="753" y="285"/>
+      <point x="753" y="683" type="curve" smooth="yes" name="dh01"/>
+      <point x="753" y="1081"/>
+      <point x="582" y="1339"/>
+      <point x="286" y="1493" type="curve" name="at01"/>
+      <point x="286" y="1636" type="line"/>
+      <point x="702" y="1531"/>
+      <point x="937" y="1177"/>
+      <point x="937" y="683" type="curve" smooth="yes" name="dh02"/>
+      <point x="937" y="189"/>
+      <point x="702" y="-165"/>
+      <point x="286" y="-270" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>


### PR DESCRIPTION
I made the parentheses rounder in all weights and styles to improve legibility and distinguish them from other types of brackets.

---
@chrissimpkins edits below:

TODO

- [x] review shapes in multiple source types
- [x] when we have settled on vertical orientation, review brackets/braces and consider alignment of all with same center positions 