### PR TITLE
[U+003C, U+003E] Made less-than `<` and greater-than `>` wider

### DIFF
--- a/source/Hack-Bold.ufo/glyphs/greater.glif
+++ b/source/Hack-Bold.ufo/glyphs/greater.glif
@@ -4,13 +4,13 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="88" y="358" type="line" name="hr00"/>
-      <point x="883" y="641" type="line" name="iv01"/>
-      <point x="88" y="926" type="line"/>
-      <point x="88" y="1176" type="line" name="av01"/>
+      <point x="88" y="268" type="line" name=""/>
+      <point x="873" y="641" type="line" name="iv01"/>
+      <point x="88" y="1016" type="line"/>
+      <point x="88" y="1276" type="line" name="av01"/>
       <point x="1145" y="760" type="line"/>
       <point x="1145" y="524" type="line"/>
-      <point x="88" y="109" type="line" name="av02"/>
+      <point x="88" y="9" type="line" name="av02"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Bold.ufo/glyphs/less.glif
+++ b/source/Hack-Bold.ufo/glyphs/less.glif
@@ -4,13 +4,13 @@
   <unicode hex="003C"/>
   <outline>
     <contour>
-      <point x="88" y="524" type="line" name="hr00"/>
+      <point x="88" y="524" type="line" name="key"/>
       <point x="88" y="760" type="line"/>
-      <point x="1145" y="1176" type="line" name="av01"/>
-      <point x="1145" y="926" type="line"/>
-      <point x="350" y="641" type="line" name="iv01"/>
-      <point x="1145" y="358" type="line"/>
-      <point x="1145" y="109" type="line" name="av02"/>
+      <point x="1145" y="1276" type="line" name="av01"/>
+      <point x="1145" y="1016" type="line"/>
+      <point x="360" y="641" type="line" name="iv01"/>
+      <point x="1145" y="268" type="line"/>
+      <point x="1145" y="9" type="line" name="av02"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-BoldItalic.ufo/glyphs/greater.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/greater.glif
@@ -4,13 +4,13 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="88" y="358" type="line" name="hr00"/>
-      <point x="883" y="641" type="line" name="iv01"/>
-      <point x="88" y="926" type="line"/>
-      <point x="88" y="1176" type="line" name="av01"/>
+      <point x="88" y="268" type="line" name="hr00"/>
+      <point x="873" y="641" type="line" name="iv01"/>
+      <point x="88" y="1016" type="line"/>
+      <point x="88" y="1276" type="line" name="av01"/>
       <point x="1145" y="760" type="line"/>
       <point x="1145" y="524" type="line"/>
-      <point x="88" y="109" type="line" name="av02"/>
+      <point x="88" y="9" type="line" name="av02"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-BoldItalic.ufo/glyphs/less.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/less.glif
@@ -6,11 +6,11 @@
     <contour>
       <point x="88" y="524" type="line" name="hr00"/>
       <point x="88" y="760" type="line"/>
-      <point x="1145" y="1176" type="line" name="av01"/>
-      <point x="1145" y="926" type="line"/>
-      <point x="350" y="641" type="line" name="iv01"/>
-      <point x="1145" y="358" type="line"/>
-      <point x="1145" y="109" type="line" name="av02"/>
+      <point x="1145" y="1276" type="line" name="av01"/>
+      <point x="1145" y="1016" type="line"/>
+      <point x="360" y="641" type="line" name="iv01"/>
+      <point x="1145" y="268" type="line"/>
+      <point x="1145" y="9" type="line" name="av02"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Italic.ufo/glyphs/greater.glif
+++ b/source/Hack-Italic.ufo/glyphs/greater.glif
@@ -4,13 +4,13 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="88" y="324" type="line" name="hr00"/>
-      <point x="938" y="641" type="line" name="iv01"/>
-      <point x="88" y="961" type="line"/>
-      <point x="88" y="1143" type="line" name="at01"/>
+      <point x="88" y="234" type="line" name="hr00"/>
+      <point x="928" y="641" type="line" name="iv01"/>
+      <point x="88" y="1051" type="line"/>
+      <point x="88" y="1243" type="line" name="at01"/>
       <point x="1145" y="725" type="line"/>
       <point x="1145" y="559" type="line"/>
-      <point x="88" y="141" type="line" name="av01"/>
+      <point x="88" y="41" type="line" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Italic.ufo/glyphs/less.glif
+++ b/source/Hack-Italic.ufo/glyphs/less.glif
@@ -6,11 +6,11 @@
     <contour>
       <point x="88" y="559" type="line" name="hr00"/>
       <point x="88" y="725" type="line"/>
-      <point x="1145" y="1143" type="line" name="at01"/>
-      <point x="1145" y="961" type="line"/>
-      <point x="295" y="641" type="line" name="iv01"/>
-      <point x="1145" y="324" type="line"/>
-      <point x="1145" y="141" type="line" name="av01"/>
+      <point x="1145" y="1243" type="line" name="at01"/>
+      <point x="1145" y="1051" type="line"/>
+      <point x="305" y="641" type="line" name="iv01"/>
+      <point x="1145" y="234" type="line"/>
+      <point x="1145" y="41" type="line" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/greater.glif
+++ b/source/Hack-Regular.ufo/glyphs/greater.glif
@@ -4,13 +4,13 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="88" y="324" type="line" name="hr00"/>
-      <point x="938" y="641" type="line" name="iv01"/>
-      <point x="88" y="961" type="line"/>
-      <point x="88" y="1143" type="line" name="at01"/>
+      <point x="88" y="234" type="line" name="hr00"/>
+      <point x="928" y="641" type="line" name="iv01"/>
+      <point x="88" y="1051" type="line"/>
+      <point x="88" y="1243" type="line" name="at01"/>
       <point x="1145" y="725" type="line"/>
       <point x="1145" y="559" type="line"/>
-      <point x="88" y="141" type="line" name="av01"/>
+      <point x="88" y="41" type="line" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Regular.ufo/glyphs/less.glif
+++ b/source/Hack-Regular.ufo/glyphs/less.glif
@@ -6,11 +6,11 @@
     <contour>
       <point x="88" y="559" type="line" name="hr00"/>
       <point x="88" y="725" type="line"/>
-      <point x="1145" y="1143" type="line" name="at01"/>
-      <point x="1145" y="961" type="line"/>
-      <point x="295" y="641" type="line" name="iv01"/>
-      <point x="1145" y="324" type="line"/>
-      <point x="1145" y="141" type="line" name="av01"/>
+      <point x="1145" y="1243" type="line" name="at01"/>
+      <point x="1145" y="1051" type="line"/>
+      <point x="305" y="641" type="line" name="iv01"/>
+      <point x="1145" y="234" type="line"/>
+      <point x="1145" y="41" type="line" name="av01"/>
     </contour>
   </outline>
   <lib>


### PR DESCRIPTION
I made the less-than and greater-than symbols wider (i.e. taller) in all weights and styles to improve legibility, especially when they are used in XML-style tags.