### PR TITLE
Add parenleft and parenright with smoother curves

### DIFF
--- a/source/Hack-Bold.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenleft.glif
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="2">
+<glyph name="parenleft" format="1">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>
     <contour>
       <point x="977" y="-205" type="line" name="hr00"/>
-      <point x="520" y="-100"/>
+      <point x="567" y="-86"/>
       <point x="244" y="255"/>
       <point x="244" y="747" type="curve" smooth="yes" name="dh01"/>
       <point x="244" y="1238"/>
-      <point x="519" y="1595"/>
+      <point x="576" y="1591.25"/>
       <point x="977" y="1700" type="curve" name="at01"/>
       <point x="977" y="1485" type="line"/>
       <point x="671" y="1359"/>

--- a/source/Hack-Bold.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenleft.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="1">
+<glyph name="parenleft" format="2">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>

--- a/source/Hack-Bold.ufo/glyphs/parenright.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenright.glif
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="2">
+<glyph name="parenright" format="1">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point x="256" y="-205" type="curve" name="hr00"/>
-      <point x="256" y="10" type="line" name="av01"/>
-      <point x="561" y="136"/>
-      <point x="724" y="389"/>
-      <point x="724" y="747" type="curve" smooth="yes" name="dh02"/>
-      <point x="724" y="1104"/>
-      <point x="562" y="1359"/>
-      <point x="256" y="1485" type="curve"/>
-      <point x="256" y="1700" type="line" name="at01"/>
-      <point x="714" y="1595"/>
-      <point x="989" y="1238"/>
-      <point x="989" y="747" type="curve" smooth="yes" name="dh01"/>
-      <point x="989" y="255"/>
-      <point x="713" y="-100"/>
+      <point x="254" y="-205" type="line" name="hr00"/>
+      <point x="664" y="-86"/>
+      <point x="987" y="255"/>
+      <point x="987" y="747" type="curve" smooth="yes" name="dh01"/>
+      <point x="987" y="1238"/>
+      <point x="655" y="1591.25"/>
+      <point x="254" y="1700" type="curve" name="at01"/>
+      <point x="254" y="1485" type="line"/>
+      <point x="560" y="1359"/>
+      <point x="722" y="1104"/>
+      <point x="722" y="747" type="curve" smooth="yes" name="dh02"/>
+      <point x="722" y="389"/>
+      <point x="559" y="136"/>
+      <point x="254" y="10" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>

--- a/source/Hack-Bold.ufo/glyphs/parenright.glif
+++ b/source/Hack-Bold.ufo/glyphs/parenright.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="1">
+<glyph name="parenright" format="2">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>

--- a/source/Hack-BoldItalic.ufo/glyphs/parenleft.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/parenleft.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="2">
+<glyph name="parenleft" format="1">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>

--- a/source/Hack-BoldItalic.ufo/glyphs/parenleft.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/parenleft.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="1">
+<glyph name="parenleft" format="2">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>

--- a/source/Hack-BoldItalic.ufo/glyphs/parenright.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/parenright.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="1">
+<glyph name="parenright" format="2">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>

--- a/source/Hack-BoldItalic.ufo/glyphs/parenright.glif
+++ b/source/Hack-BoldItalic.ufo/glyphs/parenright.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="2">
+<glyph name="parenright" format="1">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>
     <contour>
       <point x="478" y="1700" type="line" name="hr00"/>
-      <point x="805" y="1631"/>
+      <point x="792" y="1608"/>
       <point x="1010" y="1311"/>
       <point x="1010" y="873" type="curve" smooth="yes"/>
       <point x="1010" y="815"/>

--- a/source/Hack-Italic.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Italic.ufo/glyphs/parenleft.glif
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="2">
+<glyph name="parenleft" format="1">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>
     <contour>
       <point x="798" y="-206" type="line" name="hr00"/>
-      <point x="478" y="-140"/>
+      <point x="474" y="-105"/>
       <point x="284" y="155"/>
       <point x="284" y="578" type="curve" smooth="yes"/>
       <point x="284" y="1133"/>
-      <point x="619" y="1593"/>
+      <point x="630" y="1560"/>
       <point x="1100" y="1700" type="curve" name="at01"/>
       <point x="1077" y="1557" type="line"/>
       <point x="666" y="1373"/>

--- a/source/Hack-Italic.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Italic.ufo/glyphs/parenleft.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="1">
+<glyph name="parenleft" format="2">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>

--- a/source/Hack-Italic.ufo/glyphs/parenright.glif
+++ b/source/Hack-Italic.ufo/glyphs/parenright.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="1">
+<glyph name="parenright" format="2">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>

--- a/source/Hack-Italic.ufo/glyphs/parenright.glif
+++ b/source/Hack-Italic.ufo/glyphs/parenright.glif
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="2">
+<glyph name="parenright" format="1">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>
     <contour>
       <point x="508" y="1700" type="line" name="hr00"/>
-      <point x="825" y="1634"/>
+      <point x="840" y="1575"/>
       <point x="1019" y="1335"/>
       <point x="1019" y="914" type="curve" smooth="yes"/>
       <point x="1019" y="362"/>
-      <point x="681" y="-100"/>
+      <point x="717" y="-48"/>
       <point x="200" y="-205" type="curve" name="at01"/>
       <point x="223" y="-62" type="line"/>
       <point x="594" y="102"/>

--- a/source/Hack-Regular.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenleft.glif
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="2">
+<glyph name="parenleft" format="1">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>
     <contour>
       <point x="947" y="-206" type="line" name="hr00"/>
-      <point x="535.402" y="-102.405"/>
+      <point x="552" y="-51"/>
       <point x="293" y="250.821"/>
       <point x="293" y="747" type="curve" smooth="yes" name="dh01"/>
       <point x="293" y="1243.18"/>
-      <point x="535.402" y="1596.4"/>
+      <point x="555" y="1548"/>
       <point x="947" y="1700" type="curve" name="at01"/>
       <point x="947" y="1532" type="line"/>
       <point x="631.582" y="1379.21"/>

--- a/source/Hack-Regular.ufo/glyphs/parenleft.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenleft.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenleft" format="1">
+<glyph name="parenleft" format="2">
   <advance width="1233"/>
   <unicode hex="0028"/>
   <outline>

--- a/source/Hack-Regular.ufo/glyphs/parenright.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenright.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="1">
+<glyph name="parenright" format="2">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>

--- a/source/Hack-Regular.ufo/glyphs/parenright.glif
+++ b/source/Hack-Regular.ufo/glyphs/parenright.glif
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="parenright" format="2">
+<glyph name="parenright" format="1">
   <advance width="1233"/>
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point x="286" y="-206" type="curve" name="hr00"/>
-      <point x="286" y="-38" type="line" name="av01"/>
-      <point x="582" y="106"/>
-      <point x="756" y="349"/>
-      <point x="756" y="747" type="curve" smooth="yes" name="dh02"/>
-      <point x="756" y="1145"/>
-      <point x="582" y="1388"/>
-      <point x="286" y="1532" type="curve"/>
-      <point x="286" y="1700" type="line" name="at01"/>
-      <point x="702" y="1595"/>
-      <point x="940" y="1241"/>
+      <point x="286" y="-206" type="line" name="hr00"/>
+      <point x="681" y="-51"/>
+      <point x="940" y="250.821"/>
       <point x="940" y="747" type="curve" smooth="yes" name="dh01"/>
-      <point x="940" y="253"/>
-      <point x="702" y="-101"/>
+      <point x="940" y="1243.18"/>
+      <point x="678" y="1548"/>
+      <point x="286" y="1700" type="curve" name="at01"/>
+      <point x="286" y="1532" type="line"/>
+      <point x="601.418" y="1379.21"/>
+      <point x="756" y="1121.02"/>
+      <point x="756" y="747" type="curve" smooth="yes" name="dh02"/>
+      <point x="756" y="372.98"/>
+      <point x="601.418" y="114.795"/>
+      <point x="286" y="-38" type="curve" name="av01"/>
     </contour>
   </outline>
   <lib>


### PR DESCRIPTION
Submitting PR as result of discussions – https://github.com/source-foundry/alt-hack/pull/41 and https://github.com/source-foundry/Hack/pull/433

---
@chrissimpkins edits below:

Test fonts at commit eeb942b43

**macOS / Linux** download with these links and install

[ttf-eeb942b43.zip](https://github.com/source-foundry/Hack/files/2402709/ttf-eeb942b43.zip)
[web-eeb942b43.zip](https://github.com/source-foundry/Hack/files/2402710/web-eeb942b43.zip)

**Windows** users can install with the Hack test font installer at this release:

https://github.com/source-foundry/Hack-Test-Win-Installer/releases/tag/v1.2.105

The Windows installer for these dev builds installs the fonts under the family name "Hack Test" so that you can see side-by-side comparisons between the upstream default and test builds.
