### PR TITLE
Fixed Homebrew Cask install for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ We are aware of Hack support in the following package managers (with associated 
 - **Debian**: `fonts-hack-ttf`
 - **Fedora / CentOS**: `dnf-plugins-core :: heliocastro/hack-fonts :: hack-fonts`
 - **Gentoo Linux**: `media-fonts/hack`
-- **Homebrew Cask (OS X)**: `caskroom/fonts/font-hack`
+- **Homebrew Cask (OS X)**: `homebrew/cask-fonts/font-hack`
 - **Open BSD**: `fonts/hack-fonts`
 - **OpenSUSE**: `hack-fonts`
 - **Ubuntu**: `fonts-hack-ttf`


### PR DESCRIPTION
I tried to run the HomeBrew script in the readme and i received an error: **caskroom/fonts was moved. Tap homebrew/cask-fonts instead.**

I've updated the readme to include the correct script.

@mavit 
@alerque 
@jorgheymans 
@vl4dimir 
@amadio 

P.S. This is my first pull request, Thank you for the awesome font 😄 