### PR TITLE
Fix incorrect fontconfig.

### DIFF
--- a/config/fontconfig/45-Hack.conf
+++ b/config/fontconfig/45-Hack.conf
@@ -9,10 +9,10 @@
   <!-- if this file is put in user’s configuration, unset sans-serif family -->
   <match>
     <test compare="eq" name="family">
-        <string>Hack</string>
+        <string>sans-serif</string>
     </test>
     <test compare="eq" name="family">
-        <string>sans-serif</string>
+        <string>Hack</string>
     </test>
     <edit mode="delete" name="family"/>
   </match>


### PR DESCRIPTION
The current config/fontconfig is incorrect. Fontconfig deletes the first matched font family. Therefore, it actually unsets the "Hack" family instead of the "sans-serif" family.

Evidence: on my machine, after applying the upsteam 45-Hack.conf, "fc-match -s Hack" returns:
```
NotoSans-Regular.ttf: "Noto Sans" "Regular"
NotoSansJP-Regular.otf: "Noto Sans JP" "Regular"
NotoSansSC-Regular.otf: "Noto Sans SC" "Regular"
LiberationSans-Regular.ttf: "Liberation Sans" "Regular"
Cantarell-Regular.otf: "Cantarell" "Regular"
n019003l.pfb: "Nimbus Sans L" "Regular"
luxisr.ttf: "Luxi Sans" "Regular"
wqy-microhei.ttc: "WenQuanYi Micro Hei" "Regular"
```

It doesn't even return Hack match, because it is deleted.

After applying the 45-Hack.conf in this PR, "fc-match -s Hack" returns:

```
Hack-Regular.ttf: "Hack" "Regular"
Hack-Bold.ttf: "Hack" "Bold"
SourceCodePro-Regular.otf: "Source Code Pro" "Regular"
LiberationMono-Regular.ttf: "Liberation Mono" "Regular"
DejaVuSansMono.ttf: "DejaVu Sans Mono" "Book"
DejaVuSansMono-Bold.ttf: "DejaVu Sans Mono" "Bold"
DroidSansMono.ttf: "Droid Sans Mono" "Regular"
```

It returns both Hack and other monospace fonts, which is the correct behavior.
