### PR TITLE
Use systemId urn:fontconfig:fonts.dtd to reference the fonts.dtd type defintion

### DIFF
--- a/config/fontconfig/45-Hack.conf
+++ b/config/fontconfig/45-Hack.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- Declare Hack a monospace font -->
   <alias>


### PR DESCRIPTION
When packaging font for Fedora Linux, the RPM macro will check if the fontconfig is valid by running the `xmllint` command.

### Before:
```
Hack/config/fontconfig on  master
❯ xmllint --loaddtd --valid --nonet 45-Hack.conf
45-Hack.conf:2: warning: failed to load external entity "fonts.dtd"
<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
                                        ^
45-Hack.conf:3: validity error : Validation failed: no DTD found !
<fontconfig>
           ^
<?xml version="1.0"?>
<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
<fontconfig>
  <!-- Declare Hack a monospace font -->
  <alias>
    <family>Hack</family>
    <default><family>monospace</family></default>
  </alias>
  <!-- if this file is put in user’s configuration, unset sans-serif family -->
  <match>
    <test compare="eq" name="family">
        <string>sans-serif</string>
    </test>
    <test compare="eq" name="family">
        <string>Hack</string>
    </test>
    <edit mode="delete" name="family"/>
  </match>
</fontconfig>
```

### After:

```
Hack/config/fontconfig on  fontconfig
❯ xmllint --loaddtd --valid --nonet 45-Hack.conf
<?xml version="1.0"?>
<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
<fontconfig>
  <!-- Declare Hack a monospace font -->
  <alias>
    <family>Hack</family>
    <default><family>monospace</family></default>
  </alias>
  <!-- if this file is put in user’s configuration, unset sans-serif family -->
  <match>
    <test compare="eq" name="family">
        <string>sans-serif</string>
    </test>
    <test compare="eq" name="family">
        <string>Hack</string>
    </test>
    <edit mode="delete" name="family"/>
  </match>
</fontconfig>
```