### PR TITLE
Update Fedora repository in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We are aware of Hack support in the following package managers (with associated 
 - **Arch Linux**: `ttf-hack`
 - **Chocolatey (Windows)**: `hackfont`
 - **Debian**: `fonts-hack-ttf`
-- **Fedora / CentOS**: `dnf-plugins-core :: heliocastro/hack-fonts :: hack-fonts`
+- **Fedora / CentOS**: `dnf-plugins-core :: zawertun/hack-fonts :: hack-fonts`
 - **Gentoo Linux**: `media-fonts/hack`
 - **Homebrew Cask (OS X)**: `homebrew/cask-fonts/font-hack`
 - **Open BSD**: `fonts/hack-fonts`


### PR DESCRIPTION
Change the Fedora hack-fonts repository to the most up-to-date one ([zawertun/hack-fonts](https://copr.fedorainfracloud.org/coprs/zawertun/hack-fonts/)) in Copr, as the ‘heliocastro/hack-fonts’ repository no longer exists.