### PR TITLE
Fix incorrect glyph names in TTF hinting files

### DIFF
--- a/postbuild_processing/tt-hinting/Hack-Bold-TA.txt
+++ b/postbuild_processing/tt-hinting/Hack-Bold-TA.txt
@@ -1,21 +1,21 @@
 
 # U+0021 exclam glyph ID 580
-uni0021 touch 22,23,24,25    y -0.5    @14
+exclam touch 22,23,24,25    y -0.5    @14
 
 # U+0025 percent glyph ID 762
-uni0025 touch 0,1,16                     y 0.75   @10,11
-uni0025 touch 23,24,25                   y 0.25   @10,11
-uni0025 touch 17,18,32,46,47,48          y 0.5    @10,11
-uni0025 touch 57,58,71                   y -0.25  @10,11
-uni0025 touch 33,34,35,36                y 0.5    @10,11
-uni0025 touch 63,64,65                   y 0.75   @10,11
+percent touch 0,1,16                     y 0.75   @10,11
+percent touch 23,24,25                   y 0.25   @10,11
+percent touch 17,18,32,46,47,48          y 0.5    @10,11
+percent touch 57,58,71                   y -0.25  @10,11
+percent touch 33,34,35,36                y 0.5    @10,11
+percent touch 63,64,65                   y 0.75   @10,11
 
-uni0025 touch 23,24,25,63,64,65          y 0.5    @14
-uni0025 touch 17,18,32,57,58,71          y -0.5   @14
+percent touch 23,24,25,63,64,65          y 0.5    @14
+percent touch 17,18,32,57,58,71          y -0.5   @14
 
 # U+002B plus glyph ID 765
-uni002B  touch 0,1,2,3,6,7,8,9           y 0.5    @10,11
+plus  touch 0,1,2,3,6,7,8,9           y 0.5    @10,11
 
 # U+0038 eight glyph ID 556
-uni0038  touch 41,42,43                  y 0.25   @12,13,14
-uni0038  touch 34,35,48                  y -0.25  @12,13,14
+eight  touch 41,42,43                  y 0.25   @12,13,14
+eight  touch 34,35,48                  y -0.25  @12,13,14

--- a/postbuild_processing/tt-hinting/Hack-BoldItalic-TA.txt
+++ b/postbuild_processing/tt-hinting/Hack-BoldItalic-TA.txt
@@ -1,4 +1,4 @@
 
 # U+002B plus glyph ID 751
-uni002B  touch 0,1,2,3,6,7,8,9    y 0.5   @10,11
+plus  touch 0,1,2,3,6,7,8,9    y 0.5   @10,11
 

--- a/postbuild_processing/tt-hinting/Hack-Italic-TA.txt
+++ b/postbuild_processing/tt-hinting/Hack-Italic-TA.txt
@@ -7,15 +7,15 @@
 # bar touch 0,3  y -1    @ 10,14
 
 # # U+0025 percent glyph 750
-uni0025 touch 0,1,21,22,23,39    y 0.5    @10
-uni0025 touch 40                 y 0.75   @10
-uni0025 touch 41,42,43           y 0.5    @10
-uni0025 touch 51,52,53,72,73,74  y 0.5    @10
+percent touch 0,1,21,22,23,39    y 0.5    @10
+percent touch 40                 y 0.75   @10
+percent touch 41,42,43           y 0.5    @10
+percent touch 51,52,53,72,73,74  y 0.5    @10
 
-uni0025 touch 40,43              y -0.75  @11
-uni0025 touch 41,42              y 0.75   @11
+percent touch 40,43              y -0.75  @11
+percent touch 41,42              y 0.75   @11
 
-uni0025 touch 0,1,21,22,23,39    y -0.25  @14
-uni0025 touch 8,9,10,30,31,32    y 0.25   @14
-uni0025 touch 51,52,53,72,73,74  y -0.5   @14
-uni0025 touch 40,41,42,43        y -0.25  @14
+percent touch 0,1,21,22,23,39    y -0.25  @14
+percent touch 8,9,10,30,31,32    y 0.25   @14
+percent touch 51,52,53,72,73,74  y -0.5   @14
+percent touch 40,41,42,43        y -0.25  @14

--- a/postbuild_processing/tt-hinting/Hack-Regular-TA.txt
+++ b/postbuild_processing/tt-hinting/Hack-Regular-TA.txt
@@ -1,25 +1,25 @@
 
 # U+0023 numbersign glyph ID 582
-uni0023 touch 0,1,2,3,18,19,20,21,22,23,24,25,26,27,28,31 x 0.25  @ 13
+numbersign touch 0,1,2,3,18,19,20,21,22,23,24,25,26,27,28,31 x 0.25  @ 13
 
 # U+0025 percent glyph 761
-uni0025 touch 0,1,21,22,23,39    y 0.5    @10
-uni0025 touch 40                 y 0.75   @10
-uni0025 touch 41,42,43           y 0.5    @10
-uni0025 touch 51,52,53,70,71,72  y 0.5    @10
+percent touch 0,1,21,22,23,39    y 0.5    @10
+percent touch 40                 y 0.75   @10
+percent touch 41,42,43           y 0.5    @10
+percent touch 51,52,53,70,71,72  y 0.5    @10
 
-uni0025 touch 40,43              y -0.75  @11
-uni0025 touch 41,42              y 0.75   @11
+percent touch 40,43              y -0.75  @11
+percent touch 41,42              y 0.75   @11
 
-uni0025 touch 0,1,21,22,23,39    y -0.25  @14
-uni0025 touch 8,9,10,30,31,32    y 0.25   @14
-uni0025 touch 51,52,53,70,71,72  y -0.5   @14
-uni0025 touch 40,41,42,43        y -0.25  @14
+percent touch 0,1,21,22,23,39    y -0.25  @14
+percent touch 8,9,10,30,31,32    y 0.25   @14
+percent touch 51,52,53,70,71,72  y -0.5   @14
+percent touch 40,41,42,43        y -0.25  @14
 
 # U+002B plus glyph ID 764
-uni002B touch 4,5,10,11          y 0.5    @12
-uni002B touch 4,5                y 1.0    @13
+plus touch 4,5,10,11          y 0.5    @12
+plus touch 4,5                y 1.0    @13
 
 # U+0030 zero glyph ID 548
-uni0030 touch 35,36,45,46,47,56  y -0.5   @8
-uni0030 touch 35,36,56           y -1.0   @12,13,14
+zero touch 35,36,45,46,47,56  y -0.5   @8
+zero touch 35,36,56           y -1.0   @12,13,14


### PR DESCRIPTION
Thanks for fixing these, @remd!

~This resolves #500 for me (on Debian 12).~ There is still [some pixel-related issue after overwriting with an alt glyph](https://github.com/kili-ilo/Hack-with-slashed-0/pull/2/files#diff-3672a8dcfb505995ec89ba6ba63cae2262fa654b5d0d503d771a13b2553c77d2R30-R31), which I didn't bother trying to solve and instead just commented it again after overwriting, but that's a later error and only occurs when using an alt glyph.

My only modification to this commit was to remove the `# ` commenting-out of the last two lines about `zero`, which were related to the use of an alt glyph.